### PR TITLE
Fix Contacts view too slow to display

### DIFF
--- a/attachment_s3/__openerp__.py
+++ b/attachment_s3/__openerp__.py
@@ -14,6 +14,8 @@
      'python': ['boto'],
  },
  'website': 'http://www.camptocamp.com',
- 'data': [],
+ 'data': [
+     'views/res_partner_views.xml',
+ ],
  'installable': True,
  }

--- a/attachment_s3/views/res_partner_views.xml
+++ b/attachment_s3/views/res_partner_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record model="ir.ui.view" id="res_partner_kanban_view">
+      <field name="name">res.partner.kanban</field>
+      <field name="model">res.partner</field>
+      <field name="inherit_id" ref="base.res_partner_kanban_view"/>
+      <field name="arch" type="xml">
+
+        <!-- Image is too slow to load, it's especially more slow with s3
+             Replace the field with the small one (that has been fixed
+             in Odoo since 10.0)
+        -->
+        <field name="image" position="replace">
+          <field name="image_small"/>
+        </field>
+
+        <t t-if="record.image.raw_value" position="attributes">
+          <attribute name="t-if">record.image_small.raw_value</attribute>
+        </t>
+
+        <t t-if="!record.image.raw_value" position="attributes">
+          <attribute name="t-if">!record.image_small.raw_value</attribute>
+        </t>
+
+      </field>
+    </record>
+
+  </data>
+</openerp>


### PR DESCRIPTION
The 'base' Kanban view for res.partner in 9.0 loads the large 'image'
field in the 'search_read' but display the 'small_image'. The js code
also has to issue js calls to get the small images as they have not been
prefetched. This is noticeably slow to load when the large images are
read from S3 which is slower than a local filesystem/database.

This fix loads the 'small_image' instead of the large one.

This bug has been fixed in Odoo 10.0.