### PR TITLE
[9.0] Make error message more precise for S3 access

### DIFF
--- a/attachment_s3/models/ir_attachment.py
+++ b/attachment_s3/models/ir_attachment.py
@@ -135,14 +135,18 @@ class IrAttachment(models.Model):
         else:
             bucket_name = os.environ.get('AWS_BUCKETNAME')
         if not (access_key and secret_key and bucket_name):
-            raise exceptions.UserError(
-                _('The following environment variables must be set:\n'
-                  '* AWS_ACCESS_KEY_ID\n'
-                  '* AWS_SECRET_ACCESS_KEY\n'
-                  '* AWS_BUCKETNAME\n'
-                  '* AWS_HOST (optional)\n'
-                  )
-            )
+            msg = _('If you want to read from the %s S3 bucket, the following '
+                    'environment variables must be set:\n'
+                    '* AWS_ACCESS_KEY_ID\n'
+                    '* AWS_SECRET_ACCESS_KEY\n'
+                    'If you want to write in the %s S3 bucket, this variable '
+                    'must be set as well:\n'
+                    '* AWS_BUCKETNAME\n'
+                    'Optionally, the S3 host can be changed with:\n'
+                    '* AWS_HOST\n'
+                    ) % (bucket_name, bucket_name)
+
+            raise exceptions.UserError(msg)
 
         try:
             conn = connect_s3(aws_access_key_id=access_key,


### PR DESCRIPTION
The previous error message let think that you should set AWS_BUCKETNAME,
although you should set it only if you are trying to write in this
repository.