### PR TITLE
Expire sessions generated by health checks quickly

### DIFF
--- a/monitoring_status/controllers/main.py
+++ b/monitoring_status/controllers/main.py
@@ -19,4 +19,13 @@ class Monitoring(http.Controller):
         # queue job, cron, database, ...
         headers = {'Content-Type': 'application/json'}
         info = {'status': 1}
+        session = http.request.session
+        # We set a custom expiration of 1 second for this request, as we do a
+        # lot of health checks, we don't want those anonymous sessions to be
+        # kept. Beware, it works only when session_redis is used.
+        # Alternatively, we could set 'session.should_save = False', which is
+        # tested in odoo source code, but we wouldn't check the health of
+        # Redis.
+        if not session.uid:
+            session.expiration = 1
         return werkzeug.wrappers.Response(json.dumps(info), headers=headers)

--- a/session_redis/session.py
+++ b/session_redis/session.py
@@ -37,6 +37,9 @@ class RedisSessionStore(SessionStore):
     def save(self, session):
         key = self.build_key(session.sid)
 
+        # allow to set a custom expiration for a session
+        # such as a very short one for monitoring requests
+        expiration = session.expiration or self.expiration
         if _logger.isEnabledFor(logging.DEBUG):
             if session.uid:
                 user_msg = "user '%s' (id: %s)" % (
@@ -45,11 +48,11 @@ class RedisSessionStore(SessionStore):
                 user_msg = "anonymous user"
             _logger.debug("saving session with key '%s' and "
                           "expiration of %s seconds for %s",
-                          key, self.expiration, user_msg)
+                          key, expiration, user_msg)
 
         data = json.dumps(dict(session)).encode('utf-8')
         if self.redis.set(key, data):
-            return self.redis.expire(key, self.expiration)
+            return self.redis.expire(key, expiration)
 
     def delete(self, session):
         key = self.build_key(session.sid)


### PR DESCRIPTION
The default expiration of sessions is 7 days. With healthchecks run
every few seconds, we quickly have millions of anonymous sessions in
Redis. Allow to define a custom expiration for some sessions and set a
very short one for the monitoring requests.