### PR TITLE
Fix session check crash due to odoo recent change [1]

### DIFF
--- a/session_redis/__init__.py
+++ b/session_redis/__init__.py
@@ -2,3 +2,4 @@
 
 from . import http
 from . import session
+from . import models

--- a/session_redis/__manifest__.py
+++ b/session_redis/__manifest__.py
@@ -5,7 +5,7 @@
 
 {'name': 'Sessions in Redis',
  'summary': 'Store web sessions in Redis',
- 'version': '10.0.1.0.0',
+ 'version': '10.0.1.0.1',
  'author': 'Camptocamp,Odoo Community Association (OCA)',
  'license': 'AGPL-3',
  'category': 'Extra Tools',

--- a/session_redis/models/__init__.py
+++ b/session_redis/models/__init__.py
@@ -1,0 +1,1 @@
+from . import user

--- a/session_redis/models/user.py
+++ b/session_redis/models/user.py
@@ -1,0 +1,19 @@
+from odoo import models, tools
+
+
+class User(models.Model):
+    _inherit = 'res.users'
+
+    @tools.ormcache('sid')
+    def _compute_session_token(self, sid):
+        """Make sure to return an unicode string.
+
+        Odoo creates a session token using hexdigest Session which is str
+        but with redis we set the token from a dictionary of values passing
+        it in json format. When dumping values from json, we always get unicode
+        thus both are incompatible.
+
+        The shortest path is to fix the output of the computed session by Odoo.
+
+        """
+        return unicode(super(User, self)._compute_session_token(sid))


### PR DESCRIPTION
Odoo introduced a token on 2018-03-19, this token is
used for checking the rights.

The token itself is generated from data as a hash.
The redis_session module handle it correctly by saving it aside other
data in json format. Nevertheless, when reading it, from json format,
it forces all strings to unicode whereas some dumped string where str.

Thus it fails on comparison between str and unicode.

This fix solves it by always using token in unicode format.

[1] https://github.com/odoo/odoo/pull/22612