### PR TITLE
[12.0] Add https scheme if not present in AWS_HOST env var

### DIFF
--- a/attachment_s3/models/ir_attachment.py
+++ b/attachment_s3/models/ir_attachment.py
@@ -6,6 +6,7 @@ import base64
 import logging
 import os
 import io
+from urllib.parse import urlsplit
 
 from odoo import _, api, exceptions, models
 from ..s3uri import S3Uri
@@ -46,6 +47,11 @@ class IrAttachment(models.Model):
 
         """
         host = os.environ.get('AWS_HOST')
+
+        # Ensure host is prefixed with a scheme (use https as default)
+        if not urlsplit(host).scheme:
+            host = 'https://%s' % host
+
         region_name = os.environ.get('AWS_REGION')
         access_key = os.environ.get('AWS_ACCESS_KEY_ID')
         secret_key = os.environ.get('AWS_SECRET_ACCESS_KEY')


### PR DESCRIPTION
With boto (odoo < 12.0) we use an hostname as AWS_HOST.
However with boto3, the connection must be initialized using an
URL containing a scheme (e.g https://)
This commit ensures we can use a simple hostname for odoo >= v12.0
without the need of specifying the scheme in the env var.