### PR TITLE
Fix use of aws where hostname is not required

### DIFF
--- a/attachment_s3/models/ir_attachment.py
+++ b/attachment_s3/models/ir_attachment.py
@@ -49,7 +49,7 @@ class IrAttachment(models.Model):
         host = os.environ.get('AWS_HOST')
 
         # Ensure host is prefixed with a scheme (use https as default)
-        if not urlsplit(host).scheme:
+        if host and not urlsplit(host).scheme:
             host = 'https://%s' % host
 
         region_name = os.environ.get('AWS_REGION')


### PR DESCRIPTION
This fixes an error with endpoint computed as https://None while
we want to let boto compute the AWS endpoint

(which BTW fixes what we wrote in the README of the module that using AWS service doesn't require AWS_HOST)