### PR TITLE
[12.0] attachment_swift: share a session for all connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
       - python-lxml # because pip installation is slow
       - python-simplejson
       - python-serial
-      - python-yaml
 
 env:
   matrix:

--- a/attachment_swift/README.rst
+++ b/attachment_swift/README.rst
@@ -16,6 +16,7 @@ Configure accesses with environment variables:
 * ``SWIFT_TENANT_NAME``
 * ``SWIFT_ACCOUNT``
 * ``SWIFT_PASSWORD``
+* ``SWIFT_REGION_NAME``         : optional region
 * ``SWIFT_WRITE_CONTAINER``     : Name of the container to use in the store (created if not existing)
 
 Read-only mode:
@@ -44,6 +45,7 @@ The python-swiftclient can be used from the command line, useful to test:
     export OS_USERNAME={SWIFT_ACCOUNT}
     export OS_PASSWORD={SWIFT_PASSWORD}
     export OS_TENANT_NAME={SWIFT_TENANT_NAME}
+    export SWIFT_REGION_NAME={SWIFT_REGION_NAME}
     export OS_AUTH_URL=https://auth.cloud.ovh.net/v2.0
     swift stat
 

--- a/attachment_swift/__manifest__.py
+++ b/attachment_swift/__manifest__.py
@@ -12,6 +12,7 @@
  'external_dependencies': {
      'python': ['swiftclient',
                 'keystoneclient',
+                'keystoneauth1',
                 ],
  },
  'website': 'https://www.camptocamp.com',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ statsd==3.2.1
 python-swiftclient==3.7.0
 python-keystoneclient==3.19.0
 keystoneauth1==3.14.0
+# error with 5.x (ConstructorError: could not determine a constructor for the tag '!record')
+PyYAML==4.2b4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ boto3==1.9.102
 redis==2.10.5
 python-json-logger==0.1.5
 statsd==3.2.1
-python-swiftclient==3.4.0
-python-keystoneclient==3.13.0
+python-swiftclient==3.7.0
+python-keystoneclient==3.19.0
+keystoneauth1==3.14.0

--- a/setup/attachment_swift/setup.py
+++ b/setup/attachment_swift/setup.py
@@ -2,5 +2,13 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        'external_dependencies_override': {
+            'python': {
+                'swiftclient': 'python-swiftclient>=3.7.0',
+                'keystoneclient': 'python-keystoneclient>=3.19.0',
+                'keystoneauth1': 'keystoneauth1>=3.14.0',
+            },
+        },
+    }
 )


### PR DESCRIPTION
Port of #55

OVH's Swift applies a rate limit on the authentication.

attachment_swift authenticates again each time it has to read/write an
attachment. When running upgrades on upgrades of files or installing a new
DB, at some point, we get rejected with HTTP 429.

This commit introduces a shared storage for Swift Session. All connections
will reuses the same authentication token created the first time a
connection needs a Session.

Note: needs python-swiftclient>=3.7.0 to have
https://github.com/openstack/python-swiftclient/commit/1971ef880ff225379d4a91f00f89f323a1605eeb