### PR TITLE
Fix inverse datas for swift storage

### DIFF
--- a/attachment_s3/models/ir_attachment.py
+++ b/attachment_s3/models/ir_attachment.py
@@ -90,7 +90,7 @@ class IrAttachment(models.Model):
                 if fname:
                     self._file_delete(fname)
                 continue
-            self._data_set('datas', attach.datas, None)
+            attach._data_set('datas', attach.datas, None)
 
     def _register_hook(self, cr):
         super(IrAttachment, self)._register_hook(cr)


### PR DESCRIPTION
Fixes #63 
Checked locally by setting my env to write to a test swift container and setting all images to be written on swift. Then i ran the script which should move it to the db and it worked. It also works properly when its db storage from the beginning.