### PR TITLE
[9.0] Filter /monitoring/status werkzeug logs

### DIFF
--- a/monitoring_status/controllers/main.py
+++ b/monitoring_status/controllers/main.py
@@ -14,7 +14,7 @@ from openerp.addons.web.controllers.main import ensure_db
 class HealthCheckFilter(logging.Filter):
 
     def __init__(self, path, name=''):
-        super().__init__(name)
+        super(HealthCheckFilter, self).__init__(name)
         self.path = path
 
     def filter(self, record):

--- a/monitoring_status/controllers/main.py
+++ b/monitoring_status/controllers/main.py
@@ -2,12 +2,28 @@
 # Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
+import logging
 import json
 
 import werkzeug
 
 from openerp import http
 from openerp.addons.web.controllers.main import ensure_db
+
+
+class HealthCheckFilter(logging.Filter):
+
+    def __init__(self, path, name=''):
+        super().__init__(name)
+        self.path = path
+
+    def filter(self, record):
+        return self.path not in record.getMessage()
+
+
+logging.getLogger('werkzeug').addFilter(
+    HealthCheckFilter('"GET /monitoring/status HTTP/1.1"')
+)
 
 
 class Monitoring(http.Controller):


### PR DESCRIPTION
With healtchecks, they constitute 95% of our logs. Let's stop wasting
resources and shut them up.