### PR TITLE
[12.0] Add support of 'labs' RUNNING_ENV in cloud_platform

### DIFF
--- a/cloud_platform/models/cloud_platform.py
+++ b/cloud_platform/models/cloud_platform.py
@@ -106,7 +106,9 @@ class CloudPlatform(models.AbstractModel):
                 "Normally, 'swift' is activated on labs, integration "
                 "and production, but should not be used in dev environment"
                 " (or using a dedicated dev bucket, never using the "
-                "integration/prod bucket)."
+                "integration/prod bucket).\n"
+                "If you don't actually need a bucket, change the"
+                " 'ir_attachment.location' parameter."
             )
             prod_container = bool(re.match(r'[a-z0-9-]+-odoo-prod',
                                            container_name))
@@ -160,7 +162,9 @@ class CloudPlatform(models.AbstractModel):
                 "Normally, 's3' is activated on labs, integration "
                 "and production, but should not be used in dev environment"
                 " (or using a dedicated dev bucket, never using the "
-                "integration/prod bucket)."
+                "integration/prod bucket).\n"
+                "If you don't actually need a bucket, change the"
+                " 'ir_attachment.location' parameter."
             )
             prod_bucket = bool(re.match(r'[a-z-0-9]+-odoo-prod', bucket_name))
             if environment_name == 'prod':

--- a/cloud_platform_exoscale/models/cloud_platform.py
+++ b/cloud_platform_exoscale/models/cloud_platform.py
@@ -30,6 +30,7 @@ class CloudPlatform(models.AbstractModel):
         configs = {
             'prod': PlatformConfig(filestore=FilestoreKind.s3),
             'integration': PlatformConfig(filestore=FilestoreKind.s3),
+            'labs': PlatformConfig(filestore=FilestoreKind.s3),
             'test': PlatformConfig(filestore=FilestoreKind.db),
             'dev': PlatformConfig(filestore=FilestoreKind.db),
         }

--- a/cloud_platform_ovh/models/cloud_platform.py
+++ b/cloud_platform_ovh/models/cloud_platform.py
@@ -30,6 +30,7 @@ class CloudPlatform(models.AbstractModel):
         configs = {
             'prod': PlatformConfig(filestore=FilestoreKind.swift),
             'integration': PlatformConfig(filestore=FilestoreKind.swift),
+            'labs': PlatformConfig(filestore=FilestoreKind.swift),
             'test': PlatformConfig(filestore=FilestoreKind.db),
             'dev': PlatformConfig(filestore=FilestoreKind.db),
         }


### PR DESCRIPTION
The labs env can be anything starting by 'labs', such as
'labs-logistics', 'labs-finance', ...

* At install, s3/swift is set as default storage
* However, unlike prod/integration, the storage is not forced to be an
object storage
* Redis is required
* When the storage is set on s3/swift, then the bucket name is mandatory
(otherwise, there is no place where to create the files...)

The redis prefix regex match is relaxed: anything starting by a project
name, then '-odoo-', then any combination of letters, digits, and dashes
is accepted (so a prefix my-project9-odoo-labs-web3 is valid).