### PR TITLE
Add AWS_BUCKETNAME_UNSTRUCTURED to by-pass check

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Besides, the attachment location should be set to `s3` (this is
 automatically done by the `install` methods of the `cloud_platform` module).
  * `ir.config_parameter` `ir_attachment.location`: `s3`
 
+Structure of bucket name is checked against environment.
+It is possible to by-pass this behavior by using the following environment variable:
+`AWS_BUCKETNAME_UNSTRUCTURED`.
+
 
 ### Attachments in the Object Storage Swift
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Besides, the attachment location should be set to `swift` (this is
 automatically done by the `install` methods of the `cloud_platform` module).
  * `ir.config_parameter` `ir_attachment.location`: `swift`
 
+Structure of container name is checked against environment.
+It is possible to by-pass this behavior by using the following environment variable:
+`SWIFT_WRITE_CONTAINER_UNSTRUCTURED`.
+
 ### Sessions in Redis
 
 * prod:

--- a/cloud_platform/models/cloud_platform.py
+++ b/cloud_platform/models/cloud_platform.py
@@ -112,6 +112,13 @@ class CloudPlatform(models.AbstractModel):
             )
             prod_container = bool(re.match(r'[a-z0-9-]+-odoo-prod',
                                            container_name))
+            # A bucket name is defined under the following format
+            # <client>-odoo-<env>
+            #
+            # Use SWIFT_WRITE_CONTAINER_UNSTRUCTURED to by-pass check on bucket name
+            # structure
+            if os.environ.get('SWIFT_WRITE_CONTAINER_UNSTRUCTURED'):
+                return
             if environment_name == 'prod':
                 assert prod_container, (
                     "SWIFT_WRITE_CONTAINER should match '<client>-odoo-prod', "

--- a/cloud_platform/models/cloud_platform.py
+++ b/cloud_platform/models/cloud_platform.py
@@ -166,6 +166,13 @@ class CloudPlatform(models.AbstractModel):
                 "If you don't actually need a bucket, change the"
                 " 'ir_attachment.location' parameter."
             )
+            # A bucket name is defined under the following format
+            # <client>-odoo-<env>
+            #
+            # Use AWS_BUCKETNAME_UNSTRUCTURED to by-pass check on bucket name
+            # structure
+            if os.environ.get('AWS_BUCKETNAME_UNSTRUCTURED'):
+                return
             prod_bucket = bool(re.match(r'[a-z-0-9]+-odoo-prod', bucket_name))
             if environment_name == 'prod':
                 assert prod_bucket, (


### PR DESCRIPTION
Curently the name of the bucket is cross checked with the
running environment. In rare case you can have a bucket name
that doesn't match the structure `<project>-odoo-<env>` in place.