### PR TITLE
Add anonymous redis session expiration configuration

### DIFF
--- a/session_redis/README.rst
+++ b/session_redis/README.rst
@@ -16,6 +16,8 @@ The storage of sessions in Redis is activated using environment variables.
 * ``ODOO_SESSION_REDIS_PREFIX`` is the prefix for the session keys (optional)
 * ``ODOO_SESSION_REDIS_EXPIRATION`` is the time in seconds before expiration of
   the sessions (default is 7 days)
+* ``ODOO_SESSION_REDIS_EXPIRATION_ANONYMOUS`` is the time in seconds before expiration of
+  the anonymous sessions (default is 3 hours)
 
 
 The keys are set to ``session:<session id>``.

--- a/session_redis/http.py
+++ b/session_redis/http.py
@@ -41,6 +41,7 @@ port = int(os.environ.get('ODOO_SESSION_REDIS_PORT', 6379))
 prefix = os.environ.get('ODOO_SESSION_REDIS_PREFIX')
 password = os.environ.get('ODOO_SESSION_REDIS_PASSWORD')
 expiration = os.environ.get('ODOO_SESSION_REDIS_EXPIRATION')
+anon_expiration = os.environ.get('ODOO_SESSION_REDIS_EXPIRATION_ANONYMOUS')
 
 
 @lazy_property
@@ -53,6 +54,7 @@ def session_store(self):
         redis_client = redis.Redis(host=host, port=port, password=password)
     return RedisSessionStore(redis=redis_client, prefix=prefix,
                              expiration=expiration,
+                             anon_expiration=anon_expiration,
                              session_class=http.OpenERPSession)
 
 

--- a/session_redis/session.py
+++ b/session_redis/session.py
@@ -9,6 +9,7 @@ from werkzeug.contrib.sessions import SessionStore
 # this is equal to the duration of the session garbage collector in
 # odoo.http.session_gc()
 DEFAULT_SESSION_TIMEOUT = 60 * 60 * 24 * 7  # 7 days in seconds
+DEFAULT_SESSION_TIMEOUT_ANONYMOUS = 60 * 60 * 3  # 3 hours in seconds
 
 _logger = logging.getLogger(__name__)
 
@@ -17,13 +18,17 @@ class RedisSessionStore(SessionStore):
     """ SessionStore that saves session to redis """
 
     def __init__(self, redis, session_class=None,
-                 prefix='', expiration=None):
+                 prefix='', expiration=None, anon_expiration=None):
         super().__init__(session_class=session_class)
         self.redis = redis
         if expiration is None:
             self.expiration = DEFAULT_SESSION_TIMEOUT
         else:
             self.expiration = expiration
+        if anon_expiration is None:
+            self.anon_expiration = DEFAULT_SESSION_TIMEOUT_ANONYMOUS
+        else:
+            self.anon_expiration = anon_expiration
         self.prefix = 'session:'
         if prefix:
             self.prefix = '%s:%s:' % (
@@ -38,7 +43,10 @@ class RedisSessionStore(SessionStore):
 
         # allow to set a custom expiration for a session
         # such as a very short one for monitoring requests
-        expiration = session.expiration or self.expiration
+        if session.uid:
+            expiration = session.expiration or self.expiration
+        else:
+            expiration = session.expiration or self.anon_expiration
         if _logger.isEnabledFor(logging.DEBUG):
             if session.uid:
                 user_msg = "user '%s' (id: %s)" % (


### PR DESCRIPTION
Shorten the expiration time of anonymous sessions (e.g. robots or Odoo with E-Shop) in Redis.
Default value is 3 hours and can be configured through environment variable `ODOO_SESSION_REDIS_EXPIRATION_ANONYMOUS`