### PR TITLE
[13.0] Use keystoneauth v3 for Swift attachments

### DIFF
--- a/attachment_swift/README.rst
+++ b/attachment_swift/README.rst
@@ -13,7 +13,8 @@ Activate Swift storage:
 Configure accesses with environment variables:
 
 * ``SWIFT_AUTH_URL``            : URL of the Swift server
-* ``SWIFT_TENANT_NAME``
+* ``SWIFT_TENANT_NAME``         : **!** DEPRECATED **!** Use ``SWIFT_PROJECT_NAME`` instead
+* ``SWIFT_PROJECT_NAME``
 * ``SWIFT_ACCOUNT``
 * ``SWIFT_PASSWORD``
 * ``SWIFT_REGION_NAME``         : optional region
@@ -36,17 +37,19 @@ This addon must be added in the server wide addons with (``--load`` option):
 Python Dependencies
 -------------------
 
-This module needs the python-swiftclient and the python-keystoneclient (For auth v2.0) to work.
+This module needs the python-swiftclient and the python-keystoneclient (For auth v3.0) to work.
 The python-keystoneclient needs the linux package build-essential and python-dev to install properly.
 
 The python-swiftclient can be used from the command line, useful to test:
 
-    export AUTH_VERSION=2.0
+.. code-block:: sh
+
+    export AUTH_VERSION=3.0
     export OS_USERNAME={SWIFT_ACCOUNT}
     export OS_PASSWORD={SWIFT_PASSWORD}
-    export OS_TENANT_NAME={SWIFT_TENANT_NAME}
-    export SWIFT_REGION_NAME={SWIFT_REGION_NAME}
-    export OS_AUTH_URL=https://auth.cloud.ovh.net/v2.0
+    export OS_PROJECT_NAME={SWIFT_PROJECT_NAME}
+    export OS_REGION_NAME={SWIFT_REGION_NAME}
+    export OS_AUTH_URL=https://auth.cloud.ovh.net/v3
     swift stat
 
 More information at

--- a/attachment_swift/models/ir_attachment.py
+++ b/attachment_swift/models/ir_attachment.py
@@ -46,18 +46,18 @@ class SwiftSessionStore(object):
     def __init__(self):
         self._sessions = {}
 
-    def _get_key(self, auth_url, username, password, tenant_name):
-        return (auth_url, username, password, tenant_name)
+    def _get_key(self, auth_url, username, password, project_name):
+        return (auth_url, username, password, project_name)
 
     def get_session(self, auth_url=None, username=None, password=None,
-                    tenant_name=None):
-        key = self._get_key(auth_url, username, password, tenant_name)
+                    project_name=None):
+        key = self._get_key(auth_url, username, password, project_name)
         session = self._sessions.get(key)
         if not session:
-            auth = keystoneauth1.identity.v2.Password(
+            auth = keystoneauth1.identity.v3.Password(
                 username=username,
                 password=password,
-                tenant_name=tenant_name,
+                project_name=project_name,
                 auth_url=auth_url,
             )
             session = keystoneauth1.session.Session(
@@ -85,12 +85,18 @@ class IrAttachment(models.Model):
         host = os.environ.get('SWIFT_AUTH_URL')
         account = os.environ.get('SWIFT_ACCOUNT')
         password = os.environ.get('SWIFT_PASSWORD')
-        tenant_name = os.environ.get('SWIFT_TENANT_NAME')
+        project_name = os.environ.get('SWIFT_PROJECT_NAME')
+        if not project_name and os.environ.get('SWIFT_TENANT_NAME'):
+            project_name = os.environ['SWIFT_TENANT_NAME']
+            _logger.warning(
+                "SWIFT_TENANT_NAME is deprecated and "
+                "must be replaced by SWIFT_PROJECT_NAME"
+            )
         region = os.environ.get('SWIFT_REGION_NAME')
         os_options = {}
         if region:
             os_options['region_name'] = region
-        if not (host and account and password and tenant_name):
+        if not (host and account and password and project_name):
             raise exceptions.UserError(_(
                 "Problem connecting to Swift store, are the env variables "
                 "(SWIFT_AUTH_URL, SWIFT_ACCOUNT, SWIFT_PASSWORD, "
@@ -100,7 +106,7 @@ class IrAttachment(models.Model):
             session = swift_session_store.get_session(
                 username=account,
                 password=password,
-                tenant_name=tenant_name,
+                project_name=project_name,
                 auth_url=host,
             )
             conn = swiftclient.client.Connection(

--- a/attachment_swift/tests/test_mock_swift_api.py
+++ b/attachment_swift/tests/test_mock_swift_api.py
@@ -25,18 +25,20 @@ class TestAttachmentSwift(TestIrAttachment):
         auth_url = 'auth_url'
         username = 'username'
         password = 'password'
-        tenant_name = 'tenant_name'
+        project_name = 'project_name'
         store = SwiftSessionStore()
         session = store.get_session(
             auth_url=auth_url,
             username=username,
             password=password,
-            tenant_name=tenant_name,
+            project_name=project_name,
         )
         self.assertEqual(session.auth.auth_url, auth_url)
-        self.assertEqual(session.auth.username, username)
-        self.assertEqual(session.auth.password, password)
-        self.assertEqual(session.auth.tenant_name, tenant_name)
+        self.assertEqual(session.auth.get_cache_id_elements().get(
+            'password_username'), username)
+        self.assertEqual(session.auth.get_cache_id_elements().get(
+            'password_password'), password)
+        self.assertEqual(session.auth.project_name, project_name)
 
         # get the same session on a second call
         self.assertEqual(
@@ -44,7 +46,7 @@ class TestAttachmentSwift(TestIrAttachment):
                 auth_url=auth_url,
                 username=username,
                 password=password,
-                tenant_name=tenant_name,
+                project_name=project_name,
             ),
             session
         )
@@ -55,7 +57,7 @@ class TestAttachmentSwift(TestIrAttachment):
         os.environ['SWIFT_AUTH_URL'] = 'auth_url'
         os.environ['SWIFT_ACCOUNT'] = 'account'
         os.environ['SWIFT_PASSWORD'] = 'password'
-        os.environ['SWIFT_TENANT_NAME'] = 'tenant_name'
+        os.environ['SWIFT_PROJECT_NAME'] = 'project_name'
         os.environ['SWIFT_REGION_NAME'] = 'NOWHERE'
         attachment = self.Attachment
         attachment._get_swift_connection()
@@ -67,10 +69,12 @@ class TestAttachmentSwift(TestIrAttachment):
         session = kwargs['session']
         self.assertTrue(isinstance(session, keystoneauth1.session.Session))
         self.assertEqual(session.auth.auth_url, os.environ['SWIFT_AUTH_URL'])
-        self.assertEqual(session.auth.username, os.environ['SWIFT_ACCOUNT'])
-        self.assertEqual(session.auth.password, os.environ['SWIFT_PASSWORD'])
-        self.assertEqual(session.auth.tenant_name,
-                         os.environ['SWIFT_TENANT_NAME'])
+        self.assertEqual(session.auth.get_cache_id_elements().get(
+            'password_username'), os.environ['SWIFT_ACCOUNT'])
+        self.assertEqual(session.auth.get_cache_id_elements().get(
+            'password_password'), os.environ['SWIFT_PASSWORD'])
+        self.assertEqual(session.auth.project_name,
+                         os.environ['SWIFT_PROJECT_NAME'])
 
     def test_store_file_on_swift(self):
         """
@@ -81,7 +85,7 @@ class TestAttachmentSwift(TestIrAttachment):
         os.environ['SWIFT_AUTH_URL'] = 'auth_url'
         os.environ['SWIFT_ACCOUNT'] = 'account'
         os.environ['SWIFT_PASSWORD'] = 'password'
-        os.environ['SWIFT_TENANT_NAME'] = 'tenant_name'
+        os.environ['SWIFT_PROJECT_NAME'] = 'project_name'
         os.environ['SWIFT_WRITE_CONTAINER'] = 'my_container'
         container = os.environ.get('SWIFT_WRITE_CONTAINER')
         attachment = self.Attachment
@@ -103,7 +107,7 @@ class TestAttachmentSwift(TestIrAttachment):
         os.environ['SWIFT_AUTH_URL'] = 'auth_url'
         os.environ['SWIFT_ACCOUNT'] = 'account'
         os.environ['SWIFT_PASSWORD'] = 'password'
-        os.environ['SWIFT_TENANT_NAME'] = 'tenant_name'
+        os.environ['SWIFT_PROJECT_NAME'] = 'project_name'
         os.environ['SWIFT_WRITE_CONTAINER'] = 'my_container'
 
         attachment = self.Attachment


### PR DESCRIPTION
[BSCLOUDFR-6] : Changed v2 to v3 and tenant_name to project_name