### PR TITLE
Enhanced JSON Logging

### DIFF
--- a/logging_json/json_log.py
+++ b/logging_json/json_log.py
@@ -8,6 +8,8 @@ import time
 
 from distutils.util import strtobool
 from odoo.netsvc import PerfFilter
+from odoo.service.server import RequestHandler
+from werkzeug.urls import uri_to_iri
 
 _logger = logging.getLogger(__name__)
 TIMING_DP = 6
@@ -24,10 +26,10 @@ def is_true(strval):
 
 
 class OdooJsonFormatter(jsonlogger.JsonFormatter):
-
     def add_fields(self, log_record, record, message_dict):
         record.pid = os.getpid()
         record.dbname = getattr(threading.currentThread(), 'dbname', '?')
+        # Remove perf_info - it is replaced by JsonPerfFilter fields, defined below
         if hasattr(record, "perf_info"):
             delattr(record, "perf_info")
         _super = super(OdooJsonFormatter, self)
@@ -35,10 +37,9 @@ class OdooJsonFormatter(jsonlogger.JsonFormatter):
 
 
 class JsonPerfFilter(logging.Filter):
-
     def filter(self, record):
         if hasattr(threading.current_thread(), "query_count"):
-            record.request_time = round(
+            record.response_time = round(
                 time.time() - threading.current_thread().perf_t0, TIMING_DP)
             record.query_count = threading.current_thread().query_count
             record.query_time = round(
@@ -48,6 +49,8 @@ class JsonPerfFilter(logging.Filter):
 
 
 if is_true(os.environ.get('ODOO_LOGGING_JSON')):
+
+    # Replace odoo default log formatter
     format = ('%(asctime)s %(pid)s %(levelname)s'
               '%(dbname)s %(name)s: %(message)s')
     formatter = OdooJsonFormatter(format)
@@ -61,3 +64,22 @@ if is_true(os.environ.get('ODOO_LOGGING_JSON')):
             http_logger.removeFilter(f)
     json_perf_filter = JsonPerfFilter()
     http_logger.addFilter(json_perf_filter)
+
+    # Configure http request logging
+    def log_request(self, code="-", size="-"):
+        try:
+            path = uri_to_iri(self.path)
+        except AttributeError:
+            # path isn't set if the requestline was bad
+            path = self.requestline
+        record = {
+            "method": self.command,
+            "path": path,
+            "http_ver": self.request_version,
+            "http_code": str(code),
+            "size": size,
+            "client_addr": self.address_string()
+        }
+        http_logger.info('request%s', '', extra=record)
+
+    RequestHandler.log_request = log_request

--- a/logging_json/json_log.py
+++ b/logging_json/json_log.py
@@ -28,6 +28,8 @@ class OdooJsonFormatter(jsonlogger.JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         record.pid = os.getpid()
         record.dbname = getattr(threading.currentThread(), 'dbname', '?')
+        if hasattr(record, "perf_info"):
+            delattr(record, "perf_info")
         _super = super(OdooJsonFormatter, self)
         return _super.add_fields(log_record, record, message_dict)
 
@@ -42,8 +44,6 @@ class JsonPerfFilter(logging.Filter):
             record.query_time = round(
                 threading.current_thread().query_time, TIMING_DP)
             delattr(threading.current_thread(), "query_count")
-            if hasattr(record, "perf_info"):
-                delattr(record, "perf_info")
         return True
 
 


### PR DESCRIPTION
Hi guys. I've done some work on the `logging_json` module to make the output easier to work with in logging tools. There are two main changes:

* The "perf_info" string field is now split into numeric `response_time`, `query_count` and `query_time` fields
* I've overridden Odoo's `RequestHandler.log_request()` method to log out all the request info as seperate fields instead of one big long string:

Before:
```json
{
    "asctime": "2020-02-16 02:59:19,598",
    "pid": 14298,
    "levelname": "INFO",
    "dbname": "odoo13",
    "name": "werkzeug",
    "message": "192.168.56.1 - - [16/Feb/2020 02:59:19] \"GET /web/image?model=res.partner&field=image_128&id=3&unique= HTTP/1.1\" 304 -",
    "perf_info": "5 0.085 0.156"
}
```

After:
```json
{
    "asctime": "2020-02-16 02:53:00,716",
    "pid": 13919,
    "levelname": "INFO",
    "dbname": "odoo13",
    "name": "werkzeug",
    "message": "request",
    "method": "GET",
    "path": "/web/image?model=res.partner&field=image_128&id=9",
    "http_ver": "HTTP/1.1",
    "http_code": "404",
    "size": "-",
    "client_addr": "192.168.56.1",
    "response_time": 0.538973,
    "query_count": 6,
    "query_time": 0.065994
}
```

Obviously this is a breaking change, so I guess we might want a flag to enable it, maybe by setting `ODOO_LOGGING_JSON` env var to `"enhanced"`? I'm open to suggestions :)

Thanks for this great collection of modules! - I'm looking forward to implementing them for our customers :)

...As a side note, this also removes `perf_info` from non-http log entries (which never have it set)

Before:
![Screen Shot 2020-02-16 at 2 23 21 PM](https://user-images.githubusercontent.com/8173903/74598600-dd0d0f00-50d8-11ea-8fd0-fcc67cd8be6b.png)

After:
![Screen Shot 2020-02-16 at 2 23 32 PM](https://user-images.githubusercontent.com/8173903/74598594-c666b800-50d8-11ea-8b20-87fb423214ae.png)

References:
* [Odoo PerfFilter class](https://github.com/odoo/odoo/blob/13.0/odoo/netsvc.py#L74)
* [Werkzeug log_request() method](https://github.com/pallets/werkzeug/blob/0bf2e3eb13ebbe08e3591e3fde58fa52284f421c/src/werkzeug/serving.py#L406)