### PR TITLE
[11.0] Require AWS_BUCKETNAME for prod, integration and labs environments only

### DIFF
--- a/cloud_platform/models/cloud_platform.py
+++ b/cloud_platform/models/cloud_platform.py
@@ -122,17 +122,18 @@ class CloudPlatform(models.AbstractModel):
                 "SWIFT_PASSWORD environment variable is required when "
                 "ir_attachment.location is 'swift'."
             )
-            container_name = os.environ.get('SWIFT_WRITE_CONTAINER')
-            assert container_name, (
-                "SWIFT_WRITE_CONTAINER environment variable is required when "
-                "ir_attachment.location is 'swift'.\n"
-                "Normally, 'swift' is activated on labs, integration "
-                "and production, but should not be used in dev environment"
-                " (or using a dedicated dev bucket, never using the "
-                "integration/prod bucket).\n"
-                "If you don't actually need a bucket, change the"
-                " 'ir_attachment.location' parameter."
-            )
+            container_name = os.environ.get('SWIFT_WRITE_CONTAINER', '')
+            if environment_name in ('prod', 'integration', 'labs'):
+                assert container_name, (
+                    "SWIFT_WRITE_CONTAINER environment variable is required when "
+                    "ir_attachment.location is 'swift'.\n"
+                    "Normally, 'swift' is activated on labs, integration "
+                    "and production, but should not be used in dev environment"
+                    " (or using a dedicated dev bucket, never using the "
+                    "integration/prod bucket).\n"
+                    "If you don't actually need a bucket, change the"
+                    " 'ir_attachment.location' parameter."
+                )
             prod_container = bool(re.match(r'[a-z0-9-]+-odoo-prod',
                                            container_name))
             if environment_name == 'prod':
@@ -178,17 +179,18 @@ class CloudPlatform(models.AbstractModel):
                 "AWS_SECRET_ACCESS_KEY environment variable is required when "
                 "ir_attachment.location is 's3'."
             )
-            bucket_name = os.environ.get('AWS_BUCKETNAME')
-            assert bucket_name, (
-                "AWS_BUCKETNAME environment variable is required when "
-                "ir_attachment.location is 's3'.\n"
-                "Normally, 's3' is activated on labs, integration "
-                "and production, but should not be used in dev environment"
-                " (or using a dedicated dev bucket, never using the "
-                "integration/prod bucket).\n"
-                "If you don't actually need a bucket, change the"
-                " 'ir_attachment.location' parameter."
-            )
+            bucket_name = os.environ.get('AWS_BUCKETNAME', '')
+            if environment_name in ('prod', 'integration', 'labs'):
+                assert bucket_name, (
+                    "AWS_BUCKETNAME environment variable is required when "
+                    "ir_attachment.location is 's3'.\n"
+                    "Normally, 's3' is activated on labs, integration "
+                    "and production, but should not be used in dev environment"
+                    " (or using a dedicated dev bucket, never using the "
+                    "integration/prod bucket).\n"
+                    "If you don't actually need a bucket, change the"
+                    " 'ir_attachment.location' parameter."
+                )
             prod_bucket = bool(re.match(r'[a-z-0-9]+-odoo-prod', bucket_name))
             if environment_name == 'prod':
                 assert prod_bucket, (


### PR DESCRIPTION
AWS_BUCKETNAME is only needed in order to write on the bucket, but
read-only access should be allowed for other environments.

Backport of #141 