### PR TITLE
[10.0] attachment_swift: fix auth to keystone v3

### DIFF
--- a/attachment_swift/models/ir_attachment.py
+++ b/attachment_swift/models/ir_attachment.py
@@ -60,6 +60,8 @@ class SwiftSessionStore(object):
                 password=password,
                 project_name=project_name,
                 auth_url=auth_url,
+                project_domain_id='default',
+                user_domain_id='default',
             )
             session = keystoneauth1.session.Session(
                 auth=auth,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ boto==2.42.0
 redis==2.10.5
 python-json-logger==0.1.5
 statsd==3.2.1
-python-swiftclient==3.7.0
-python-keystoneclient==3.19.0
+python-swiftclient==3.9.0
+python-keystoneclient==3.22.0
 keystoneauth1==3.14.0
 # error with 5.x (ConstructorError: could not determine a constructor for the tag '!record')
 PyYAML==4.2b4


### PR DESCRIPTION
 - Use newer version from python lib.
 - Define project_domain_id + user_domain_id in auth

Fixes #162 