### PR TITLE
WIP: [11.0] Make attachment_s3 support Minio

### DIFF
--- a/attachment_s3/README.rst
+++ b/attachment_s3/README.rst
@@ -20,7 +20,7 @@ Configure accesses with environment variables:
 * ``AWS_REGION`` (required if using AWS services)
 * ``AWS_ACCESS_KEY_ID``
 * ``AWS_SECRET_ACCESS_KEY``
-* ``AWS_BUCKETNAME``
+* ``AWS_BUCKETNAME`` (or system parameter ``ir_attachment.bucketname``)
 
 Read-only mode:
 

--- a/attachment_s3/README.rst
+++ b/attachment_s3/README.rst
@@ -15,6 +15,8 @@ Activate S3 storage:
 Configure accesses with environment variables:
 
 * ``AWS_HOST`` (not required if using AWS services)
+* ``AWS_PORT`` (not required if using AWS services)
+* ``AWS_IS_SECURE`` (not required if using AWS services)
 * ``AWS_REGION`` (required if using AWS services)
 * ``AWS_ACCESS_KEY_ID``
 * ``AWS_SECRET_ACCESS_KEY``

--- a/attachment_s3/models/ir_attachment.py
+++ b/attachment_s3/models/ir_attachment.py
@@ -15,6 +15,7 @@ _logger = logging.getLogger(__name__)
 
 try:
     import boto
+    from boto.s3.connection import OrdinaryCallingFormat
     from boto.exception import S3ResponseError
 except ImportError:
     boto = None  # noqa
@@ -46,6 +47,8 @@ class IrAttachment(models.Model):
 
         """
         host = os.environ.get('AWS_HOST')
+        port = os.environ.get('AWS_PORT')
+        is_secure = os.environ.get('AWS_IS_SECURE', 'true').lower() == 'true'
         region_name = os.environ.get('AWS_REGION')
         access_key = os.environ.get('AWS_ACCESS_KEY_ID')
         secret_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
@@ -57,6 +60,14 @@ class IrAttachment(models.Model):
         }
         if host:
             params['host'] = host
+            params['calling_format'] = OrdinaryCallingFormat()
+
+        if port:
+            params['port'] = int(port)
+
+        if not is_secure:
+            params['is_secure'] = False
+
         if region_name:
             # needs specific method for region
             connect_s3 = boto.s3.connect_to_region

--- a/attachment_s3/models/ir_attachment.py
+++ b/attachment_s3/models/ir_attachment.py
@@ -8,7 +8,7 @@ import logging
 import os
 import xml.dom.minidom
 
-from odoo import _, api, exceptions, models
+from odoo import _, api, exceptions, models, tools
 from ..s3uri import S3Uri
 
 _logger = logging.getLogger(__name__)
@@ -52,7 +52,7 @@ class IrAttachment(models.Model):
         region_name = os.environ.get('AWS_REGION')
         access_key = os.environ.get('AWS_ACCESS_KEY_ID')
         secret_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
-        bucket_name = name or os.environ.get('AWS_BUCKETNAME')
+        bucket_name = name or tools.config.get('ir_attachment.bucketname') or os.environ.get('AWS_BUCKETNAME')
 
         params = {
             'aws_access_key_id': access_key,


### PR DESCRIPTION
- Added `AWS_PORT` environment variable setting because Minio by default runs in a different port
- Added `AWS_IS_SECURE` environment variable setting because if you run Minio in a secure network, you want to set this `False`
- Made it possible to define the bucket name in the config parameter called `ir_attachment.bucketname` if you want to use a different buckets in different databases.

Related discussion: https://odoo-community.org/groups/contributors-15/contributors-158468?mode=thread&date_begin=&date_end=

A quick way to set up Minio with Docker Compose for development purposes:
```
version: "2"
services:
  minio:
    image: minio/minio:latest
    command: server /data
    ports:
      - "127.0.0.1:9000:9000"
    environment:
      MINIO_BROWSER: 'on'
      MINIO_ACCESS_KEY: minioaccesskey
      MINIO_SECRET_KEY: miniosecretkey
```

And define the following environment variables for Odoo:
```
AWS_ACCESS_KEY_ID: minioaccesskey
AWS_SECRET_ACCESS_KEY: miniosecretkey
AWS_BUCKETNAME: odoo
AWS_HOST: minio
AWS_PORT: 9000
AWS_IS_SECURE: 'False'
```