### PR TITLE
11.0 session redis preserve sessions

### DIFF
--- a/session_redis/README.rst
+++ b/session_redis/README.rst
@@ -18,6 +18,10 @@ The storage of sessions in Redis is activated using environment variables.
   the sessions (default is 7 days)
 * ``ODOO_SESSION_REDIS_EXPIRATION_ANONYMOUS`` is the time in seconds before expiration of
   the anonymous sessions (default is 3 hours)
+* ``ODOO_SESSION_REDIS_COPY_EXISTING_FS_SESSIONS`` when ``1`` or ``true`` copies the existing odoo sessions from
+  the filesystem to redis when starting
+* ``ODOO_SESSION_REDIS_PURGE_EXISTING_FS_SESSIONS`` when ``1`` or ``true`` deletes the existing odoo sessions from
+  the filesystem to redis when starting
 
 
 The keys are set to ``session:<session id>``.
@@ -32,8 +36,12 @@ Limitations
 
 * The server has to be restarted in order for the sessions to be stored in
   Redis.
-* All the users will have to login again as their previous session will be
-  dropped.
 * The addon monkey-patch ``odoo.http.Root.session_store`` with a custom
   method when the Redis mode is active, so incompatibilities with other addons
   is possible if they do the same.
+
+Preseve Sessions
+----------------
+
+In order to preserve sessions when switching to redis run odoo with
+``ODOO_SESSION_REDIS_COPY_EXISTING_FS_SESSIONS=true odoo --load session_redis --stop-after-init``

--- a/session_redis/__init__.py
+++ b/session_redis/__init__.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 from . import http
 from . import session

--- a/session_redis/__manifest__.py
+++ b/session_redis/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 

--- a/session_redis/__manifest__.py
+++ b/session_redis/__manifest__.py
@@ -16,4 +16,5 @@
  'website': 'http://www.camptocamp.com',
  'data': [],
  'installable': True,
+ 'post_load': False,
  }

--- a/session_redis/http.py
+++ b/session_redis/http.py
@@ -77,6 +77,20 @@ def purge_fs_sessions(path):
             pass
 
 
+def copy_fs_sessions(path):
+    from odoo.http import OpenERPSession
+    import werkzeug.contrib.sessions
+    werkzeug_session_store = werkzeug.contrib.sessions.FilesystemSessionStore(path, session_class=OpenERPSession)
+    session_store = http.Root().session_store
+    filename_prefix='werkzeug_'
+    filename_suffix = '.sess'
+
+    for fname in os.listdir(path):
+        path = os.path.join(path, fname)
+        session = werkzeug_session_store.get(fname[len(filename_prefix):len(filename_suffix) * -1])
+        session_store.save(session)
+
+
 if is_true(os.environ.get('ODOO_SESSION_REDIS')):
     if sentinel_host:
         _logger.debug("HTTP sessions stored in Redis with prefix '%s'. "
@@ -88,5 +102,9 @@ if is_true(os.environ.get('ODOO_SESSION_REDIS')):
 
     http.Root.session_store = session_store
     http.session_gc = session_gc
-    # clean the existing sessions on the file system
-    purge_fs_sessions(odoo.tools.config.session_dir)
+
+    if is_true(os.environ.get('ODOO_SESSION_REDIS_COPY_EXISTING_FS_SESSIONS')):
+        copy_fs_sessions(odoo.tools.config.session_dir)
+    if is_true(os.environ.get('ODOO_SESSION_REDIS_PURGE_EXISTING_FS_SESSIONS')):
+        # clean the existing sessions on the file system
+        purge_fs_sessions(odoo.tools.config.session_dir)

--- a/session_redis/http.py
+++ b/session_redis/http.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
@@ -79,15 +78,15 @@ def purge_fs_sessions(path):
 
 def copy_fs_sessions(path):
     from odoo.http import OpenERPSession
-    import werkzeug.contrib.sessions
-    werkzeug_session_store = werkzeug.contrib.sessions.FilesystemSessionStore(path, session_class=OpenERPSession)
+    from werkzeug.contrib.sessions import FilesystemSessionStore
+    werkzeug_session_store = FilesystemSessionStore(path, session_class=OpenERPSession)
     session_store = http.Root().session_store
-    filename_prefix='werkzeug_'
-    filename_suffix = '.sess'
+    filename_prefix_len = len('werkzeug_')
+    filename_suffix_len = len('.sess')
 
     for fname in os.listdir(path):
-        path = os.path.join(path, fname)
-        session = werkzeug_session_store.get(fname[len(filename_prefix):len(filename_suffix) * -1])
+        session_file = fname[filename_prefix_len:filename_suffix_len * -1]
+        session = werkzeug_session_store.get(session_file)
         session_store.save(session)
 
 

--- a/session_redis/session.py
+++ b/session_redis/session.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 


### PR DESCRIPTION
When testing the session redis store on one of our instances we didn't want to destroy 2.6 million sessions.

With making the purge sessions feature optional we prevent purging all the sessions (that are still used by other odoo instances with the same session dir) when just testing it works.

Also added a copy odoo session feature that allows copying existing sessions to redis before restarting odoo with redis session store in effect. This helps reducing the number of sessions lost when switching to redis.

Info @wt-io-it