### PR TITLE
Encode/decode date and datetime in redis sessions

### DIFF
--- a/session_redis/json_encoding.py
+++ b/session_redis/json_encoding.py
@@ -1,0 +1,39 @@
+# Copyright 2016-2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import json
+
+from datetime import date, datetime
+
+import dateutil
+
+
+class SessionEncoder(json.JSONEncoder):
+    """Encode date/datetime objects
+
+    So that we can later recompose them if they were stored in the session
+    """
+
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return {"_type": "datetime_isoformat", "value": obj.isoformat()}
+        elif isinstance(obj, date):
+            return {"_type": "date_isoformat", "value": obj.isoformat()}
+        return json.JSONEncoder.default(self, obj)
+
+
+class SessionDecoder(json.JSONDecoder):
+    """Decode json, recomposing recordsets and date/datetime"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(object_hook=self.object_hook, *args, **kwargs)
+
+    def object_hook(self, obj):
+        if "_type" not in obj:
+            return obj
+        type_ = obj["_type"]
+        if type_ == "datetime_isoformat":
+            return dateutil.parser.parse(obj["value"])
+        elif type_ == "date_isoformat":
+            return dateutil.parser.parse(obj["value"]).date()
+        return obj

--- a/session_redis/json_encoding.py
+++ b/session_redis/json_encoding.py
@@ -19,6 +19,8 @@ class SessionEncoder(json.JSONEncoder):
             return {"_type": "datetime_isoformat", "value": obj.isoformat()}
         elif isinstance(obj, date):
             return {"_type": "date_isoformat", "value": obj.isoformat()}
+        elif isinstance(obj, set):
+            return {"_type": "set", "value": tuple(obj)}
         return json.JSONEncoder.default(self, obj)
 
 
@@ -36,4 +38,6 @@ class SessionDecoder(json.JSONDecoder):
             return dateutil.parser.parse(obj["value"])
         elif type_ == "date_isoformat":
             return dateutil.parser.parse(obj["value"]).date()
+        elif type_ == "set":
+            return set(obj["value"])
         return obj


### PR DESCRIPTION
In several places, odoo sets a datetime object directly in the
session. It works with the default session handler of odoo which
uses pickle.

But datetime and date are not json serializable by default.

Add custom encoder / decoder to handle them (from
https://github.com/OCA/queue/blob/dc12a6a20ecfd15c5b90f9b089c9a64cf9d8bbe4/queue_job/fields.py#L57-L99)

See the discussion raised by @PCatinean on https://github.com/camptocamp/odoo-cloud-platform/pull/176