### PR TITLE
[12.0] Fix build after changes in server_environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ install:
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
-  - if [ "$LINT_CHECK" != "1" ] ; then ln -s ${HOME}/dependencies/server-env/server_environment_files_sample ${HOME}/dependencies/server-env/server_environment_files; fi
-  - printf '[options]\n\nrunning_env = dev' > ${HOME}/.openerp_serverrc
 
 script:
   - travis_run_tests


### PR DESCRIPTION
Now the default env is "test", and we don't need the directory
at all.
See https://github.com/OCA/server-env/pull/44