### PR TITLE
[13.0] Fix domain for finding attachments to store in DB

### DIFF
--- a/base_attachment_object_storage/models/ir_attachment.py
+++ b/base_attachment_object_storage/models/ir_attachment.py
@@ -94,8 +94,8 @@ class IrAttachment(models.Model):
             ('res_model', 'not in', excluded_model_for_db_store),
         ]
         domain += ['|'] * (len(mimetypes_for_db_store) - 1)
-        domain += [('mimetype', '=like', mimetype) for mimetype in
-                   mimetypes_for_db_store]
+        domain += [('mimetype', '=like', '{}%'.format(mimetype))
+                   for mimetype in mimetypes_for_db_store]
         return domain
 
     def _save_in_db_anyway(self):


### PR DESCRIPTION
'=like' is converted to a normal sql LIKE, as the configuration for
mimetypes is "image" and not "image/png", "image/jpeg", ... we have
to search using a wildcard pattern suffix
