### PR TITLE
[13.0] Rework and fix storage forced in database

### DIFF
--- a/attachment_s3/README.rst
+++ b/attachment_s3/README.rst
@@ -34,6 +34,10 @@ This addon must be added in the server wide addons with (``--load`` option):
 
 ``--load=web,attachment_s3``
 
+The System Parameter ``ir_attachment.storage.force.database`` can be customized to
+force storage of files in the database. See the documentation of the module
+``base_attachment_object_storage``.
+
 Limitations
 -----------
 

--- a/attachment_swift/README.rst
+++ b/attachment_swift/README.rst
@@ -34,6 +34,10 @@ This addon must be added in the server wide addons with (``--load`` option):
 
 ``--load=web,attachment_swift``
 
+The System Parameter ``ir_attachment.storage.force.database`` can be customized to
+force storage of files in the database. See the documentation of the module
+``base_attachment_object_storage``.
+
 Python Dependencies
 -------------------
 

--- a/base_attachment_object_storage/README.rst
+++ b/base_attachment_object_storage/README.rst
@@ -3,5 +3,38 @@ Base class for attachments on external object store
 
 This is a base addon that regroup common code used by addons targeting specific object store 
 
+Configuration
+-------------
 
+Object storage may be slow, and for this reason, we want to store
+some files in the database whatever.
 
+Small images (128, 256) are used in Odoo in list / kanban views. We
+want them to be fast to read.
+They are generally < 50KB (default configuration) so they don't take
+that much space in database, but they'll be read much faster than from
+the object storage.
+
+The assets (application/javascript, text/css) are stored in database
+as well whatever their size is:
+
+* a database doesn't have thousands of them
+* of course better for performance
+* better portability of a database: when replicating a production
+  instance for dev, the assets are included
+
+This storage configuration can be modified in the system parameter
+``ir_attachment.storage.force.database``, as a JSON value, for instance::
+
+    {"image/": 51200, "application/javascript": 0, "text/css": 0}
+
+Where the key is the beginning of the mimetype to configure and the
+value is the limit in size below which attachments are kept in DB.
+0 means no limit.
+
+Default configuration means:
+
+* images mimetypes (image/png, image/jpeg, ...) below 50KB are
+  stored in database
+* application/javascript are stored in database whatever their size
+* text/css are stored in database whatever their size

--- a/base_attachment_object_storage/data/res_config_settings_data.xml
+++ b/base_attachment_object_storage/data/res_config_settings_data.xml
@@ -1,16 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
 <odoo noupdate="1">
-    <record id="default_mimes_type_storedb" model="ir.config_parameter">
-        <field name="key">mimetypes.list.storedb</field>
-        <field name="value">image</field>
-    </record>
-    <record id="default_file_maxsize_storedb" model="ir.config_parameter">
-        <field name="key">file.maxsize.storedb</field>
-        <field name="value">50000</field>
-    </record>
-    <record id="excluded_model_storedb" model="ir.config_parameter">
-        <field name="key">excluded.models.storedb</field>
-        <field name="value">mail.message,mail.mail</field>
+
+    <record id="ir_attachment_storage_force_database" model="ir.config_parameter">
+        <field name="key">ir_attachment.storage.force.database</field>
+        <field name="value">{"image/": 51200, "application/javascript": 0, "text/css": 0}</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
The initial issue that triggered this rework is that the forced storage in
database was working only on writes, and was never applied on attachment
creations.

This feature is used to store small files that need to be read in a fast way in
database rather than in the object storage. Reading a file from the object
storage can take 150-200ms, which is fine for downloading a PDF file or a single
image, but not if you need 40 thumbnails.

Down the path to make a correction, I found that:

* the logic to force storage was called in `_inverse_datas`, which is not called
  during a create
* odoo implemented a new method `_get_datas_related_values`, which is a model
  method that receive only the data and the mimetype, and return the attachment
  values and write the file to the correct place

The `_get_datas_related_values` is where we want to plug this special storage,
as it is called for create and write, and already handle the values and
conditional write. But using this method, we have less information than before
about the attachment, so let's review the different criterias we had before:

* res_model: we were using it to always store attachments related to
  'ir.ui.view' in db, because assets are related to this model. However, we
  don't really need to check this: we should store any javascript and css
  documents in database.
* exclude res_model: we could have an exclusion list, to tell that for instance,
  for mail.message, we should never store any image in db. We don't have this
  information anymore, but I think it was never used and added "in case of".
  Because the default configuration is "mail.mail" and "mail.message" and I
  couldn't find any attachment with such res_model in any of our biggest
  databases. So this is removed.
* mimetype and data (size) are the last criteria and we still have them

The new system is only based on mimetype and data size and I think it's actually
more versatile. Previously, we could set a global size and include mimetypes,
but we couldn't say "I want to store all images below 50KB and all files of type
X below 10KB". Now, we have a single system parameter with a dict configuration
(`ir_attachment.storage.force.database`) defaulting to:

    {"image/": 50000, "application/javascript": 0, "text/css": 0}

Assets have a limit of zero, which means they will all be stored in the database
whatever their size is.

Overall, this is a great simplification of the module too, as the method
`_get_datas_related_values` integrates it better in the base calls of IrAttachment.

Note for upgrade:

I doubt we customized the previous system parameters which are now obsolete, but
if yes, the configuration may need to be moved to `ir_attachment.storage.force.database`.
For the record, the params were:

* mimetypes.list.storedb (default: image)
* file.maxsize.storedb (default: 50000)
* excluded.models.storedb (mail.message,mail.mail), no equivalent now

The method `IrAttachment.force_storage_to_db_for_special_fields()` should be called
through a migration script on existing databases to move the attachments back into
the database.
