### PR TITLE
[13.0] Set test_base_fileurl_field installable

### DIFF
--- a/setup/test_base_fileurl_field/odoo/addons/test_base_fileurl_field
+++ b/setup/test_base_fileurl_field/odoo/addons/test_base_fileurl_field
@@ -1,0 +1,1 @@
+../../../../test_base_fileurl_field

--- a/setup/test_base_fileurl_field/setup.py
+++ b/setup/test_base_fileurl_field/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/test_base_fileurl_field/__manifest__.py
+++ b/test_base_fileurl_field/__manifest__.py
@@ -14,6 +14,6 @@
         "views/res_partner.xml",
         "views/res_users.xml",
     ],
-    'installable': False,
+    'installable': True,
     'auto_install': False,
 }


### PR DESCRIPTION
It seems it has been forgotten during the migration of
base_fileurl_field at 65cdd3d
