### PR TITLE
[13.0] attachement_s3: odoo.modules.registry class name and API changed

### DIFF
--- a/attachment_s3/migrations/13.0.0.0.1/post-migration.py
+++ b/attachment_s3/migrations/13.0.0.0.1/post-migration.py
@@ -23,7 +23,7 @@ def migrate(cr, version):
 
     if row[0] == 's3' and bucket:
         uid = odoo.SUPERUSER_ID
-        registry = odoo.modules.registry.RegistryManager.get(cr.dbname)
+        registry = odoo.modules.registry.Registry(cr.dbname)
         new_cr = registry.cursor()
         with closing(new_cr):
             with odoo.api.Environment.manage():

--- a/attachment_s3/migrations/13.0.0.0.1/post-migration.py
+++ b/attachment_s3/migrations/13.0.0.0.1/post-migration.py
@@ -23,7 +23,7 @@ def migrate(cr, version):
 
     if row[0] == 's3' and bucket:
         uid = odoo.SUPERUSER_ID
-        registry = odoo.modules.registry.Registry.get(cr.dbname)
+        registry = odoo.modules.registry.RegistryManager.get(cr.dbname)
         new_cr = registry.cursor()
         with closing(new_cr):
             with odoo.api.Environment.manage():


### PR DESCRIPTION
Reverts camptocamp/odoo-cloud-platform#195

The API doesn't need the getter anymore to retrieve a database. The Registry class instantiation just need the dbname parameter to do the same job as previously