### PR TITLE
[FIX] attachment modules: remove base64 encoding when reading files from storage

### DIFF
--- a/attachment_s3/models/ir_attachment.py
+++ b/attachment_s3/models/ir_attachment.py
@@ -2,7 +2,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 
-import base64
 import logging
 import os
 import io
@@ -125,7 +124,7 @@ class IrAttachment(models.Model):
                 with io.BytesIO() as res:
                     bucket.download_fileobj(key, res)
                     res.seek(0)
-                    read = base64.b64encode(res.read())
+                    read = res.read()
             except ClientError:
                 read = ''
                 _logger.info(

--- a/attachment_swift/models/ir_attachment.py
+++ b/attachment_swift/models/ir_attachment.py
@@ -2,7 +2,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 
-import base64
 import logging
 import os
 from ..swift_uri import SwiftUri
@@ -132,9 +131,10 @@ class IrAttachment(models.Model):
                 )
                 return ''
             try:
-                resp, obj_content = conn.get_object(swifturi.container(),
-                                                    swifturi.item())
-                read = base64.b64encode(obj_content)
+                resp, read = conn.get_object(
+                    swifturi.container(),
+                    swifturi.item()
+                )
             except ClientException:
                 read = ''
                 _logger.exception(


### PR DESCRIPTION
Odoo now awaits binary content instead of base64 encoded content when reading the attachments