### PR TITLE
[14.0] attachment_s3: multi-tenancy use db name in bucket

### DIFF
--- a/attachment_s3/README.rst
+++ b/attachment_s3/README.rst
@@ -18,7 +18,7 @@ Configure accesses with environment variables:
 * ``AWS_REGION`` (required if using AWS services)
 * ``AWS_ACCESS_KEY_ID``
 * ``AWS_SECRET_ACCESS_KEY``
-* ``AWS_BUCKETNAME``
+* ``AWS_BUCKETNAME`` (optional {db} placeholder)
 
 Read-only mode:
 
@@ -37,6 +37,18 @@ This addon must be added in the server wide addons with (``--load`` option):
 The System Parameter ``ir_attachment.storage.force.database`` can be customized to
 force storage of files in the database. See the documentation of the module
 ``base_attachment_object_storage``.
+
+Multi-tenancy
+-------------
+
+Use the `{db}` placeholder to handle multi-tenancy.
+
+On instances that hold multiple databases, it's preferable to have one bucket per database.
+
+To handle this, you can insert the `{db}` placeholder in your bucket name variable ``AWS_BUCKETNAME``.
+It will be replaced by the database name.
+This will give you a unique bucketname per database.
+
 
 Limitations
 -----------

--- a/attachment_s3/models/ir_attachment.py
+++ b/attachment_s3/models/ir_attachment.py
@@ -55,6 +55,8 @@ class IrAttachment(models.Model):
         access_key = os.environ.get('AWS_ACCESS_KEY_ID')
         secret_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
         bucket_name = name or os.environ.get('AWS_BUCKETNAME')
+        # replaces {db} by the database name to handle multi-tenancy
+        bucket_name.format(db=self.env.cr.dbname)
 
         params = {
             'aws_access_key_id': access_key,


### PR DESCRIPTION
Adds the possibility to insert `{db}` placeholder in the bucket name
that will be replaced by the database name to form a unique bucket
name per database.

Superseeds #218