### PR TITLE
[12.0] [FIX] Bucket name formatting

### DIFF
--- a/attachment_s3/models/ir_attachment.py
+++ b/attachment_s3/models/ir_attachment.py
@@ -57,7 +57,7 @@ class IrAttachment(models.Model):
         secret_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
         bucket_name = name or os.environ.get('AWS_BUCKETNAME')
         # replaces {db} by the database name to handle multi-tenancy
-        bucket_name.format(db=self.env.cr.dbname)
+        bucket_name = bucket_name.format(db=self.env.cr.dbname)
 
         params = {
             'aws_access_key_id': access_key,


### PR DESCRIPTION
The formatted value was not really assigned to bucket_name, so the previous commit didn't really have any effect.

Backport #229 