### PR TITLE
[13.0][IMP] Make cloud_platform fully abstract + update related modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,12 @@ addons:
 env:
   matrix:
   - LINT_CHECK="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo"
-  - TESTS="1" ODOO_REPO="OCA/OCB"
+  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="cloud_platform_exoscale"
+  - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="cloud_platform_exoscale"
+  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="cloud_platform_ovh"
+  - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="cloud_platform_ovh"
+  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="cloud_platform,cloud_platform_ovh,cloud_platform_exoscale"
+  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="cloud_platform,cloud_platform_ovh,cloud_platform_exoscale"
   global:
   - VERSION="13.0" LINT_CHECK="0" TESTS="0"
 

--- a/cloud_platform/README.rst
+++ b/cloud_platform/README.rst
@@ -6,7 +6,7 @@ common to all platform providers.
 
 * Provide a quick install that we can call at the setup / migration
   of a database
-* Check if the environment variables are configured correctly according
-  to the instance's environment (prod, integration, test or dev) to prevent
+* Implements abstract methods to check if the environment variables are configured correctly
+  according to the instance's environment (prod, integration, test or dev) to prevent
   data corruption between the environments (such as the integration server
   writing on the production object storage).

--- a/cloud_platform/__manifest__.py
+++ b/cloud_platform/__manifest__.py
@@ -12,8 +12,6 @@
      'session_redis',
      'monitoring_status',
      'logging_json',
-     # 'monitoring_log_requests',
-     'monitoring_statsd',
      'server_environment',  # OCA/server-tools
  ],
  'website': 'https://www.camptocamp.com',

--- a/cloud_platform/models/cloud_platform.py
+++ b/cloud_platform/models/cloud_platform.py
@@ -124,7 +124,7 @@ class CloudPlatform(models.AbstractModel):
         if not kind:
             _logger.warning(
                 "cloud platform not configured, you should "
-                "probably run 'env['cloud.platform'].install_exoscale()'"
+                "probably run 'env['cloud.platform'].install()'"
             )
             return
         environment_name = self._get_running_env()

--- a/cloud_platform/models/cloud_platform.py
+++ b/cloud_platform/models/cloud_platform.py
@@ -6,7 +6,6 @@ import os
 import re
 
 from collections import namedtuple
-
 from distutils.util import strtobool
 
 from odoo import api, models
@@ -26,19 +25,26 @@ PlatformConfig = namedtuple(
 )
 
 
-class FilestoreKind(object):
-    db = 'db'
-    s3 = 's3'  # or compatible s3 object storage
-    swift = 'swift'
-    file = 'file'
-
-
-DefaultConfig = PlatformConfig(filestore=FilestoreKind.db)
+FilestoreKind = namedtuple(
+    'FilestoreKind',
+    ['name', 'location']
+)
 
 
 class CloudPlatform(models.AbstractModel):
     _name = 'cloud.platform'
     _description = 'cloud.platform'
+
+    @api.model
+    def _default_config(self):
+        return PlatformConfig(self._filestore_kinds()['db'])
+
+    @api.model
+    def _filestore_kinds(self):
+        return {
+            'db': FilestoreKind('db', 'local'),
+            'file': FilestoreKind('file', 'local'),
+        }
 
     @api.model
     def _platform_kinds(self):
@@ -52,7 +58,7 @@ class CloudPlatform(models.AbstractModel):
             None
         )
         configs = configs_getter() if configs_getter else {}
-        return configs.get(environment) or DefaultConfig
+        return configs.get(environment) or self._default_config()
 
     def _get_running_env(self):
         environment_name = config['running_env']
@@ -63,150 +69,25 @@ class CloudPlatform(models.AbstractModel):
         return environment_name
 
     @api.model
-    def install(self, platform_kind):
+    def _install(self, platform_kind):
         assert platform_kind in self._platform_kinds()
         params = self.env['ir.config_parameter'].sudo()
         params.set_param('cloud.platform.kind', platform_kind)
         environment_name = self._get_running_env()
         configs = self._config_by_server_env(platform_kind, environment_name)
-        params.set_param('ir_attachment.location', configs.filestore)
+        params.set_param('ir_attachment.location', configs.filestore.name)
         self.check()
-        if configs.filestore in [FilestoreKind.swift, FilestoreKind.s3]:
+        if configs.filestore.location == 'remote':
             self.env['ir.attachment'].sudo().force_storage()
         _logger.info('cloud platform configured for {}'.format(platform_kind))
 
     @api.model
-    def _check_swift(self, environment_name):
-        params = self.env['ir.config_parameter'].sudo()
-        use_swift = (params.get_param('ir_attachment.location') ==
-                     FilestoreKind.swift)
-        if environment_name in ('prod', 'integration'):
-            # Labs instances use swift or s3 by default, but we don't want
-            # to enforce it in case we want to test something with a different
-            # storage. At your own risks!
-            assert use_swift, (
-                "Swift must be used on production and integration instances. "
-                "It is activated, setting 'ir_attachment.location.' to 'swift'"
-                " The 'install_exoscale()' function sets this option "
-                "automatically."
-            )
-        if use_swift:
-            assert os.environ.get('SWIFT_AUTH_URL'), (
-                "SWIFT_AUTH_URL environment variable is required when "
-                "ir_attachment.location is 'swift'."
-            )
-            assert os.environ.get('SWIFT_ACCOUNT'), (
-                "SWIFT_ACCOUNT environment variable is required when "
-                "ir_attachment.location is 'swift'."
-            )
-            assert os.environ.get('SWIFT_PASSWORD'), (
-                "SWIFT_PASSWORD environment variable is required when "
-                "ir_attachment.location is 'swift'."
-            )
-            container_name = os.environ.get('SWIFT_WRITE_CONTAINER', '')
-            if environment_name in ('prod', 'integration', 'labs'):
-                assert container_name, (
-                    "SWIFT_WRITE_CONTAINER environment variable is required when "
-                    "ir_attachment.location is 'swift'.\n"
-                    "Normally, 'swift' is activated on labs, integration "
-                    "and production, but should not be used in dev environment"
-                    " (or using a dedicated dev bucket, never using the "
-                    "integration/prod bucket).\n"
-                    "If you don't actually need a bucket, change the"
-                    " 'ir_attachment.location' parameter."
-                )
-            prod_container = bool(re.match(r'[a-z0-9-]+-odoo-prod',
-                                           container_name))
-            # A bucket name is defined under the following format
-            # <client>-odoo-<env>
-            #
-            # Use SWIFT_WRITE_CONTAINER_UNSTRUCTURED to by-pass check on bucket name
-            # structure
-            if os.environ.get('SWIFT_WRITE_CONTAINER_UNSTRUCTURED'):
-                return
-            if environment_name == 'prod':
-                assert prod_container, (
-                    "SWIFT_WRITE_CONTAINER should match '<client>-odoo-prod', "
-                    "we got: '%s'" % (container_name,)
-                )
-            else:
-                # if we are using the prod bucket on another instance
-                # such as an integration, we must be sure to be in read only!
-                assert not prod_container, (
-                    "SWIFT_WRITE_CONTAINER should not match "
-                    "'<client>-odoo-prod', we got: '%s'" % (container_name,)
-                )
-        elif environment_name == 'test':
-            # store in DB so we don't have files local to the host
-            assert params.get_param('ir_attachment.location') == 'db', (
-                "In test instances, files must be stored in the database with "
-                "'ir_attachment.location' set to 'db'. This is "
-                "automatically set by the function 'install_ovh()'."
-            )
+    def install(self):
+        raise NotImplementedError
 
     @api.model
-    def _check_s3(self, environment_name):
-        params = self.env['ir.config_parameter'].sudo()
-        use_s3 = params.get_param('ir_attachment.location') == FilestoreKind.s3
-        if environment_name in ('prod', 'integration'):
-            # Labs instances use swift or s3 by default, but we don't want
-            # to enforce it in case we want to test something with a different
-            # storage. At your own risks!
-            assert use_s3, (
-                "S3 must be used on production and integration instances. "
-                "It is activated by setting 'ir_attachment.location.' to 's3'."
-                " The 'install_exoscale()' function sets this option "
-                "automatically."
-            )
-        if use_s3:
-            assert os.environ.get('AWS_ACCESS_KEY_ID'), (
-                "AWS_ACCESS_KEY_ID environment variable is required when "
-                "ir_attachment.location is 's3'."
-            )
-            assert os.environ.get('AWS_SECRET_ACCESS_KEY'), (
-                "AWS_SECRET_ACCESS_KEY environment variable is required when "
-                "ir_attachment.location is 's3'."
-            )
-            bucket_name = os.environ.get('AWS_BUCKETNAME', '')
-            if environment_name in ('prod', 'integration', 'labs'):
-                assert bucket_name, (
-                    "AWS_BUCKETNAME environment variable is required when "
-                    "ir_attachment.location is 's3'.\n"
-                    "Normally, 's3' is activated on labs, integration "
-                    "and production, but should not be used in dev environment"
-                    " (or using a dedicated dev bucket, never using the "
-                    "integration/prod bucket).\n"
-                    "If you don't actually need a bucket, change the"
-                    " 'ir_attachment.location' parameter."
-                )
-            # A bucket name is defined under the following format
-            # <client>-odoo-<env>
-            #
-            # Use AWS_BUCKETNAME_UNSTRUCTURED to by-pass check on bucket name
-            # structure
-            if os.environ.get('AWS_BUCKETNAME_UNSTRUCTURED'):
-                return
-            prod_bucket = bool(re.match(r'[a-z-0-9]+-odoo-prod', bucket_name))
-            if environment_name == 'prod':
-                assert prod_bucket, (
-                    "AWS_BUCKETNAME should match '<client>-odoo-prod', "
-                    "we got: '%s'" % (bucket_name,)
-                )
-            else:
-                # if we are using the prod bucket on another instance
-                # such as an integration, we must be sure to be in read only!
-                assert not prod_bucket, (
-                    "AWS_BUCKETNAME should not match '<client>-odoo-prod', "
-                    "we got: '%s'" % (bucket_name,)
-                )
-
-        elif environment_name == 'test':
-            # store in DB so we don't have files local to the host
-            assert params.get_param('ir_attachment.location') == 'db', (
-                "In test instances, files must be stored in the database with "
-                "'ir_attachment.location' set to 'db'. This is "
-                "automatically set by the function 'install_exoscale()'."
-            )
+    def _check_filestore(self, environment_name):
+        raise NotImplementedError
 
     @api.model
     def _check_redis(self, environment_name):
@@ -247,10 +128,7 @@ class CloudPlatform(models.AbstractModel):
             )
             return
         environment_name = self._get_running_env()
-        if kind == 'exoscale':
-            self._check_s3(environment_name)
-        elif kind == 'ovh':
-            self._check_swift(environment_name)
+        self._check_filestore(environment_name)
         self._check_redis(environment_name)
 
     def _register_hook(self):

--- a/cloud_platform/songs.py
+++ b/cloud_platform/songs.py
@@ -1,7 +1,3 @@
 
-def install_exoscale(ctx):
-    ctx.env['cloud.platform'].install('exoscale')
-
-
-def install_ovh(ctx):
-    ctx.env['cloud.platform'].install('ovh')
+def install(ctx):
+    ctx.env['cloud.platform'].install()

--- a/cloud_platform_exoscale/__manifest__.py
+++ b/cloud_platform_exoscale/__manifest__.py
@@ -2,18 +2,22 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 
-{'name': 'Cloud Platform Exoscale',
- 'summary': 'Addons required for the Camptocamp Cloud Platform on Exoscale',
- 'version': '13.0.1.0.0',
- 'author': 'Camptocamp,Odoo Community Association (OCA)',
- 'license': 'AGPL-3',
- 'category': 'Extra Tools',
- 'depends': [
-     'cloud_platform',
-     'attachment_s3',
-     'monitoring_statsd',
- ],
- 'website': 'https://www.camptocamp.com',
- 'data': [],
- 'installable': True,
- }
+{
+    "name": "Cloud Platform Exoscale",
+    "summary": "Addons required for the Camptocamp Cloud Platform on Exoscale",
+    "version": "13.0.1.0.0",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "category": "Extra Tools",
+    "depends": [
+        "cloud_platform",
+        "attachment_s3",
+        "monitoring_statsd",
+    ],
+    "excludes": [
+        "cloud_platform_ovh",
+    ],
+    "website": "https://www.camptocamp.com",
+    "data": [],
+    "installable": True,
+}

--- a/cloud_platform_exoscale/__manifest__.py
+++ b/cloud_platform_exoscale/__manifest__.py
@@ -11,6 +11,7 @@
  'depends': [
      'cloud_platform',
      'attachment_s3',
+     'monitoring_statsd',
  ],
  'website': 'https://www.camptocamp.com',
  'data': [],

--- a/cloud_platform_exoscale/models/cloud_platform.py
+++ b/cloud_platform_exoscale/models/cloud_platform.py
@@ -1,23 +1,25 @@
 # Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
-import logging
+import re
+import os
 
 from odoo import models, api
+from odoo.addons.cloud_platform.models.cloud_platform import FilestoreKind
+from odoo.addons.cloud_platform.models.cloud_platform import PlatformConfig
 
-_logger = logging.getLogger(__name__)
 
-try:
-    from odoo.addons.cloud_platform.models.cloud_platform import FilestoreKind
-    from odoo.addons.cloud_platform.models.cloud_platform import PlatformConfig
-except ImportError:
-    FilestoreKind = None
-    PlatformConfig = None
-    _logger.debug("Cannot 'import from cloud_platform'")
+S3_STORE_KIND = FilestoreKind('s3', 'remote')
 
 
 class CloudPlatform(models.AbstractModel):
     _inherit = 'cloud.platform'
+
+    @api.model
+    def _filestore_kinds(self):
+        kinds = super(CloudPlatform, self)._filestore_kinds()
+        kinds['s3'] = S3_STORE_KIND
+        return kinds
 
     @api.model
     def _platform_kinds(self):
@@ -27,15 +29,81 @@ class CloudPlatform(models.AbstractModel):
 
     @api.model
     def _config_by_server_env_for_exoscale(self):
+        fs_kinds = self._filestore_kinds()
         configs = {
-            'prod': PlatformConfig(filestore=FilestoreKind.s3),
-            'integration': PlatformConfig(filestore=FilestoreKind.s3),
-            'labs': PlatformConfig(filestore=FilestoreKind.s3),
-            'test': PlatformConfig(filestore=FilestoreKind.db),
-            'dev': PlatformConfig(filestore=FilestoreKind.db),
+            'prod': PlatformConfig(filestore=fs_kinds['s3']),
+            'integration': PlatformConfig(filestore=fs_kinds['s3']),
+            'labs': PlatformConfig(filestore=fs_kinds['s3']),
+            'test': PlatformConfig(filestore=fs_kinds['db']),
+            'dev': PlatformConfig(filestore=fs_kinds['db']),
         }
         return configs
 
     @api.model
-    def install_exoscale(self):
-        self.install('exoscale')
+    def _check_filestore(self, environment_name):
+        params = self.env['ir.config_parameter'].sudo()
+        use_s3 = (params.get_param('ir_attachment.location') ==
+                  S3_STORE_KIND.name)
+        if environment_name in ('prod', 'integration'):
+            # Labs instances use swift or s3 by default, but we don't want
+            # to enforce it in case we want to test something with a different
+            # storage. At your own risks!
+            assert use_s3, (
+                "S3 must be used on production and integration instances. "
+                "It is activated by setting 'ir_attachment.location.' to 's3'."
+                " The 'install_exoscale()' function sets this option "
+                "automatically."
+            )
+        if use_s3:
+            assert os.environ.get('AWS_ACCESS_KEY_ID'), (
+                "AWS_ACCESS_KEY_ID environment variable is required when "
+                "ir_attachment.location is 's3'."
+            )
+            assert os.environ.get('AWS_SECRET_ACCESS_KEY'), (
+                "AWS_SECRET_ACCESS_KEY environment variable is required when "
+                "ir_attachment.location is 's3'."
+            )
+            bucket_name = os.environ.get('AWS_BUCKETNAME', '')
+            if environment_name in ('prod', 'integration', 'labs'):
+                assert bucket_name, (
+                    "AWS_BUCKETNAME environment variable is required when "
+                    "ir_attachment.location is 's3'.\n"
+                    "Normally, 's3' is activated on labs, integration "
+                    "and production, but should not be used in dev environment"
+                    " (or using a dedicated dev bucket, never using the "
+                    "integration/prod bucket).\n"
+                    "If you don't actually need a bucket, change the"
+                    " 'ir_attachment.location' parameter."
+                )
+            # A bucket name is defined under the following format
+            # <client>-odoo-<env>
+            #
+            # Use AWS_BUCKETNAME_UNSTRUCTURED to by-pass check on bucket name
+            # structure
+            if os.environ.get('AWS_BUCKETNAME_UNSTRUCTURED'):
+                return
+            prod_bucket = bool(re.match(r'[a-z-0-9]+-odoo-prod', bucket_name))
+            if environment_name == 'prod':
+                assert prod_bucket, (
+                    "AWS_BUCKETNAME should match '<client>-odoo-prod', "
+                    "we got: '%s'" % (bucket_name,)
+                )
+            else:
+                # if we are using the prod bucket on another instance
+                # such as an integration, we must be sure to be in read only!
+                assert not prod_bucket, (
+                    "AWS_BUCKETNAME should not match '<client>-odoo-prod', "
+                    "we got: '%s'" % (bucket_name,)
+                )
+
+        elif environment_name == 'test':
+            # store in DB so we don't have files local to the host
+            assert params.get_param('ir_attachment.location') == 'db', (
+                "In test instances, files must be stored in the database with "
+                "'ir_attachment.location' set to 'db'. This is "
+                "automatically set by the function 'install_exoscale()'."
+            )
+
+    @api.model
+    def install(self):
+        self._install('exoscale')

--- a/cloud_platform_exoscale/models/cloud_platform.py
+++ b/cloud_platform_exoscale/models/cloud_platform.py
@@ -45,13 +45,13 @@ class CloudPlatform(models.AbstractModel):
         use_s3 = (params.get_param('ir_attachment.location') ==
                   S3_STORE_KIND.name)
         if environment_name in ('prod', 'integration'):
-            # Labs instances use swift or s3 by default, but we don't want
+            # Labs instances use s3 by default, but we don't want
             # to enforce it in case we want to test something with a different
             # storage. At your own risks!
             assert use_s3, (
                 "S3 must be used on production and integration instances. "
                 "It is activated by setting 'ir_attachment.location.' to 's3'."
-                " The 'install_exoscale()' function sets this option "
+                " The 'install()' function sets this option "
                 "automatically."
             )
         if use_s3:
@@ -101,7 +101,7 @@ class CloudPlatform(models.AbstractModel):
             assert params.get_param('ir_attachment.location') == 'db', (
                 "In test instances, files must be stored in the database with "
                 "'ir_attachment.location' set to 'db'. This is "
-                "automatically set by the function 'install_exoscale()'."
+                "automatically set by the function 'install()'."
             )
 
     @api.model

--- a/cloud_platform_ovh/__manifest__.py
+++ b/cloud_platform_ovh/__manifest__.py
@@ -11,6 +11,7 @@
  'depends': [
      'cloud_platform',
      'attachment_swift',
+     'monitoring_statsd',
  ],
  'website': 'https://www.camptocamp.com',
  'data': [],

--- a/cloud_platform_ovh/__manifest__.py
+++ b/cloud_platform_ovh/__manifest__.py
@@ -2,18 +2,22 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 
-{'name': 'Cloud Platform OVH',
- 'summary': 'Addons required for the Camptocamp Cloud Platform on OVH',
- 'version': '13.0.1.0.0',
- 'author': 'Camptocamp,Odoo Community Association (OCA)',
- 'license': 'AGPL-3',
- 'category': 'Extra Tools',
- 'depends': [
-     'cloud_platform',
-     'attachment_swift',
-     'monitoring_statsd',
- ],
- 'website': 'https://www.camptocamp.com',
- 'data': [],
- 'installable': True,
- }
+{
+    "name": "Cloud Platform OVH",
+    "summary": "Addons required for the Camptocamp Cloud Platform on OVH",
+    "version": "13.0.1.0.0",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "category": "Extra Tools",
+    "depends": [
+        "cloud_platform",
+        "attachment_swift",
+        "monitoring_statsd",
+    ],
+    "excludes": [
+        "cloud_platform_exoscale",
+    ],
+    "website": "https://www.camptocamp.com",
+    "data": [],
+    "installable": True,
+}

--- a/cloud_platform_ovh/models/cloud_platform.py
+++ b/cloud_platform_ovh/models/cloud_platform.py
@@ -1,23 +1,26 @@
 # Copyright 2017-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
-import logging
+import re
+import os
 
 from odoo import api, models
 
-_logger = logging.getLogger(__name__)
+from odoo.addons.cloud_platform.models.cloud_platform import FilestoreKind
+from odoo.addons.cloud_platform.models.cloud_platform import PlatformConfig
 
-try:
-    from odoo.addons.cloud_platform.models.cloud_platform import FilestoreKind
-    from odoo.addons.cloud_platform.models.cloud_platform import PlatformConfig
-except ImportError:
-    FilestoreKind = None
-    PlatformConfig = None
-    _logger.debug("Cannot 'import from cloud_platform'")
+
+SWIFT_STORE_KIND = FilestoreKind('s3', 'remote')
 
 
 class CloudPlatform(models.AbstractModel):
     _inherit = 'cloud.platform'
+
+    @api.model
+    def _filestore_kinds(self):
+        kinds = super(CloudPlatform, self)._filestore_kinds()
+        kinds['swift'] = SWIFT_STORE_KIND
+        return kinds
 
     @api.model
     def _platform_kinds(self):
@@ -27,15 +30,85 @@ class CloudPlatform(models.AbstractModel):
 
     @api.model
     def _config_by_server_env_for_ovh(self):
+        fs_kinds = self._filestore_kinds()
         configs = {
-            'prod': PlatformConfig(filestore=FilestoreKind.swift),
-            'integration': PlatformConfig(filestore=FilestoreKind.swift),
-            'labs': PlatformConfig(filestore=FilestoreKind.swift),
-            'test': PlatformConfig(filestore=FilestoreKind.db),
-            'dev': PlatformConfig(filestore=FilestoreKind.db),
+            'prod': PlatformConfig(filestore=fs_kinds['swift']),
+            'integration': PlatformConfig(filestore=fs_kinds['swift']),
+            'labs': PlatformConfig(filestore=fs_kinds['swift']),
+            'test': PlatformConfig(filestore=fs_kinds['db']),
+            'dev': PlatformConfig(filestore=fs_kinds['db']),
         }
         return configs
 
     @api.model
-    def install_ovh(self):
-        self.install('ovh')
+    def _check_filestore(self, environment_name):
+        params = self.env['ir.config_parameter'].sudo()
+        use_swift = (params.get_param('ir_attachment.location') ==
+                     SWIFT_STORE_KIND.name)
+        if environment_name in ('prod', 'integration'):
+            # Labs instances use swift or s3 by default, but we don't want
+            # to enforce it in case we want to test something with a different
+            # storage. At your own risks!
+            assert use_swift, (
+                "Swift must be used on production and integration instances. "
+                "It is activated, setting 'ir_attachment.location.' to 'swift'"
+                " The 'install_exoscale()' function sets this option "
+                "automatically."
+            )
+        if use_swift:
+            assert os.environ.get('SWIFT_AUTH_URL'), (
+                "SWIFT_AUTH_URL environment variable is required when "
+                "ir_attachment.location is 'swift'."
+            )
+            assert os.environ.get('SWIFT_ACCOUNT'), (
+                "SWIFT_ACCOUNT environment variable is required when "
+                "ir_attachment.location is 'swift'."
+            )
+            assert os.environ.get('SWIFT_PASSWORD'), (
+                "SWIFT_PASSWORD environment variable is required when "
+                "ir_attachment.location is 'swift'."
+            )
+            container_name = os.environ.get('SWIFT_WRITE_CONTAINER', '')
+            if environment_name in ('prod', 'integration', 'labs'):
+                assert container_name, (
+                    "SWIFT_WRITE_CONTAINER environment variable is required when "
+                    "ir_attachment.location is 'swift'.\n"
+                    "Normally, 'swift' is activated on labs, integration "
+                    "and production, but should not be used in dev environment"
+                    " (or using a dedicated dev bucket, never using the "
+                    "integration/prod bucket).\n"
+                    "If you don't actually need a bucket, change the"
+                    " 'ir_attachment.location' parameter."
+                )
+            prod_container = bool(re.match(r'[a-z0-9-]+-odoo-prod',
+                                           container_name))
+            # A bucket name is defined under the following format
+            # <client>-odoo-<env>
+            #
+            # Use SWIFT_WRITE_CONTAINER_UNSTRUCTURED to by-pass check on bucket name
+            # structure
+            if os.environ.get('SWIFT_WRITE_CONTAINER_UNSTRUCTURED'):
+                return
+            if environment_name == 'prod':
+                assert prod_container, (
+                    "SWIFT_WRITE_CONTAINER should match '<client>-odoo-prod', "
+                    "we got: '%s'" % (container_name,)
+                )
+            else:
+                # if we are using the prod bucket on another instance
+                # such as an integration, we must be sure to be in read only!
+                assert not prod_container, (
+                    "SWIFT_WRITE_CONTAINER should not match "
+                    "'<client>-odoo-prod', we got: '%s'" % (container_name,)
+                )
+        elif environment_name == 'test':
+            # store in DB so we don't have files local to the host
+            assert params.get_param('ir_attachment.location') == 'db', (
+                "In test instances, files must be stored in the database with "
+                "'ir_attachment.location' set to 'db'. This is "
+                "automatically set by the function 'install_ovh()'."
+            )
+
+    @api.model
+    def install(self):
+        self._install('ovh')

--- a/cloud_platform_ovh/models/cloud_platform.py
+++ b/cloud_platform_ovh/models/cloud_platform.py
@@ -46,13 +46,13 @@ class CloudPlatform(models.AbstractModel):
         use_swift = (params.get_param('ir_attachment.location') ==
                      SWIFT_STORE_KIND.name)
         if environment_name in ('prod', 'integration'):
-            # Labs instances use swift or s3 by default, but we don't want
+            # Labs instances use swift by default, but we don't want
             # to enforce it in case we want to test something with a different
             # storage. At your own risks!
             assert use_swift, (
                 "Swift must be used on production and integration instances. "
                 "It is activated, setting 'ir_attachment.location.' to 'swift'"
-                " The 'install_exoscale()' function sets this option "
+                " The 'install()' function sets this option "
                 "automatically."
             )
         if use_swift:
@@ -106,7 +106,7 @@ class CloudPlatform(models.AbstractModel):
             assert params.get_param('ir_attachment.location') == 'db', (
                 "In test instances, files must be stored in the database with "
                 "'ir_attachment.location' set to 'db'. This is "
-                "automatically set by the function 'install_ovh()'."
+                "automatically set by the function 'install()'."
             )
 
     @api.model


### PR DESCRIPTION
Make `cloud_platform` module fully abstract and update `cloud_platform_exoscale` and `cloud_platform_ovh` accordingly.
This is to simplify the addition of other platform providers