### PR TITLE
[9.0][IMP] session_redis: allow configuring Redis URL instead of host & port.

### DIFF
--- a/session_redis/README.rst
+++ b/session_redis/README.rst
@@ -13,6 +13,8 @@ The storage of sessions in Redis is activated using environment variables.
 * ``ODOO_SESSION_REDIS_PORT`` is the redis port (default is ``6379``)
 * ``ODOO_SESSION_REDIS_PASSWORD`` is the password for the AUTH command
   (optional)
+* ``ODOO_SESSION_REDIS_URL`` is an alternative way to define the Redis server
+  address. It's the preferred way when you're using the ``rediss://`` protocol.
 * ``ODOO_SESSION_REDIS_PREFIX`` is the prefix for the session keys (optional)
 * ``ODOO_SESSION_REDIS_EXPIRATION`` is the time in seconds before expiration of
   the sessions (default is 7 days)

--- a/session_redis/http.py
+++ b/session_redis/http.py
@@ -40,6 +40,7 @@ sentinel_port = int(os.environ.get('ODOO_SESSION_REDIS_SENTINEL_PORT', 26379))
 host = os.environ.get('ODOO_SESSION_REDIS_HOST', 'localhost')
 port = int(os.environ.get('ODOO_SESSION_REDIS_PORT', 6379))
 prefix = os.environ.get('ODOO_SESSION_REDIS_PREFIX')
+url = os.environ.get('ODOO_SESSION_REDIS_URL')
 password = os.environ.get('ODOO_SESSION_REDIS_PASSWORD')
 expiration = os.environ.get('ODOO_SESSION_REDIS_EXPIRATION')
 anon_expiration = os.environ.get('ODOO_SESSION_REDIS_EXPIRATION_ANONYMOUS')
@@ -51,6 +52,8 @@ def session_store(self):
         sentinel = Sentinel([(sentinel_host, sentinel_port)],
                             password=password)
         redis_client = sentinel.master_for(sentinel_master_name)
+    elif url:
+        redis_client = redis.from_url(url)
     else:
         redis_client = redis.Redis(host=host, port=port, password=password)
     return RedisSessionStore(redis=redis_client, prefix=prefix,


### PR DESCRIPTION
Back-porting from [13] branch