### PR TITLE
[15.0] Fix travis Force Python version on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ sudo: false
 cache: pip
 
 python:
-  - "3.7"
+  # Force a newer version than 3.7.1 which break build
+  # due to https://bugs.python.org/issue34921
+  - "3.7.2"
 
 addons:
   postgresql: "9.5"


### PR DESCRIPTION
This fixes an error

    TypeError: Plain typing.NoReturn is not valid as type argument

The error is due to a bug in Python 2.7.1

https://bugs.python.org/issue34921