### PR TITLE
[9.0] attachment_swift: Restore compat in test

### DIFF
--- a/attachment_swift/tests/test_mock_swift_api.py
+++ b/attachment_swift/tests/test_mock_swift_api.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2017-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
@@ -9,15 +10,15 @@ from mock import patch
 
 import keystoneauth1
 
-from odoo.addons.base.tests.test_ir_attachment import TestIrAttachment
-from odoo.addons.attachment_swift.models.ir_attachment import SwiftSessionStore
-from odoo.addons.attachment_swift.swift_uri import SwiftUri
+from openerp.addons.base.tests.test_ir_attachment import test_ir_attachment
+from openerp.addons.attachment_swift.models.ir_attachment import SwiftSessionStore
+from openerp.addons.attachment_swift.swift_uri import SwiftUri
 
 
-class TestAttachmentSwift(TestIrAttachment):
+class TestAttachmentSwift(test_ir_attachment):
 
     def setup(self):
-        super().setUp()
+        super(TestAttachmentSwift, self).setUp()
         self.env['ir.config_parameter'].set_param('ir_attachment.location',
                                                   'swift')
 

--- a/attachment_swift/tests/test_with_swift_store.py
+++ b/attachment_swift/tests/test_with_swift_store.py
@@ -2,12 +2,12 @@
 # Copyright 2017 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
-from openerp.addons.base.tests.test_ir_attachment import TestIrAttachment
+from openerp.addons.base.tests.test_ir_attachment import test_ir_attachment
 from ..swift_uri import SwiftUri
 from swiftclient.exceptions import ClientException
 
 
-class TestAttachmentSwift(TestIrAttachment):
+class TestAttachmentSwift(test_ir_attachment):
     """
     Those tests are made to be run against a real Swift store (local or remote)
     """


### PR DESCRIPTION
Restore import to openerp and py2.7 compat