### PR TITLE
fix: do not try to create container every time

### DIFF
--- a/attachment_azure/models/ir_attachment.py
+++ b/attachment_azure/models/ir_attachment.py
@@ -134,14 +134,13 @@ class IrAttachment(models.Model):
             container_name = self._get_container_name()
         blob_service_client = self._get_blob_service_client()
         container_client = blob_service_client.get_container_client(container_name)
-        try:
-            # Create the container
-            container_client.create_container()
-        except ResourceExistsError:
-            pass
-        except HttpResponseError as error:
-            _logger.exception("Error during the creation of the Azure container")
-            raise exceptions.UserError(str(error))
+        if not container_client.exists():
+            try:
+                # Create the container
+                container_client.create_container()
+            except HttpResponseError as error:
+                _logger.exception("Error during the creation of the Azure container")
+                raise exceptions.UserError(str(error))
         return container_client
 
     @api.model


### PR DESCRIPTION
* Purpose
In some case you want to read an other container that you have access only on readonly
ex: read production container datas from your validation instance.
Without this patch, odoo will check that the container exist by trying to create it, and it will raise an azure error, unauthorized.
We simply list available container, and check if the container that we need to access is in the list, if not we try to create it

