### PR TITLE
BSQOQ-647: allow instance profiles authentication

### DIFF
--- a/attachment_s3/models/ir_attachment.py
+++ b/attachment_s3/models/ir_attachment.py
@@ -58,10 +58,12 @@ class IrAttachment(models.Model):
         # replaces {db} by the database name to handle multi-tenancy
         bucket_name = bucket_name.format(db=self.env.cr.dbname)
         params = {
-            'aws_access_key_id': access_key,
-            'aws_secret_access_key': secret_key,
             'bucket_name': bucket_name,
         }
+        if access_key:
+            params['aws_access_key_id'] = access_key
+        if secret_key:
+            params['aws_secret_access_key'] = secret_key
         if host:
             params['endpoint_url'] = host
         if region_name:
@@ -89,8 +91,6 @@ class IrAttachment(models.Model):
         #  keyword argument 'bucket_name'
         bucket_name = params.pop("bucket_name")
         if not (
-            params["aws_access_key_id"] and
-            params["aws_secret_access_key"] and
             bucket_name
         ):
             msg = _('If you want to read from the %s S3 bucket, the following '


### PR DESCRIPTION
By dropping the requirement to have `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` envvars set, we can let the more secure IAM instance-profile take over the authentication.

This can be used immediatly on the rancher platform, and NB that this will become a requirement on the kubernetes platform in a couple of weeks.