### PR TITLE
Object Storage - disable mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,8 @@ environment. It will refuse to start if anything is badly configured.
 
 The checks can be bypassed with the environment variable
 `ODOO_CLOUD_PLATFORM_UNSAFE` set to `1`.
+
+### Attachment storage inactivation 
+
+To prevent object storage to be accessed while failing for any kind of reason
+set this environment variable `ATTACHMENT_STORAGE_INACTIVE` set to `1`.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ environment. It will refuse to start if anything is badly configured.
 The checks can be bypassed with the environment variable
 `ODOO_CLOUD_PLATFORM_UNSAFE` set to `1`.
 
-### Attachment storage inactivation 
+### Attachment storage disability 
 
 To prevent object storage to be accessed while failing for any kind of reason
-set this environment variable `ATTACHMENT_STORAGE_INACTIVE` set to `1`.
+set this environment variable `DISABLE_ATTACHMENT_STORAGE` set to `1`.

--- a/base_attachment_object_storage/README.rst
+++ b/base_attachment_object_storage/README.rst
@@ -1,7 +1,7 @@
 Base class for attachments on external object store
 ===================================================
 
-This is a base addon that regroup common code used by addons targeting specific object store 
+This is a base addon that regroup common code used by addons targeting specific object store
 
 Configuration
 -------------
@@ -38,3 +38,9 @@ Default configuration means:
   stored in database
 * application/javascript are stored in database whatever their size
 * text/css are stored in database whatever their size
+
+Inactivate attachment storage I/O
+---------------------------------
+
+Define a environment variable `ATTACHMENT_STORAGE_INACTIVE` set to `1`
+This will prevent any kind of exceptions and read/write on storage attachments.

--- a/base_attachment_object_storage/README.rst
+++ b/base_attachment_object_storage/README.rst
@@ -39,8 +39,8 @@ Default configuration means:
 * application/javascript are stored in database whatever their size
 * text/css are stored in database whatever their size
 
-Inactivate attachment storage I/O
----------------------------------
+Disable attachment storage I/O
+------------------------------
 
-Define a environment variable `ATTACHMENT_STORAGE_INACTIVE` set to `1`
+Define a environment variable `DISABLE_ATTACHMENT_STORAGE` set to `1`
 This will prevent any kind of exceptions and read/write on storage attachments.

--- a/base_fileurl_field/fields.py
+++ b/base_fileurl_field/fields.py
@@ -35,6 +35,7 @@ class FileURL(fields.Binary):
         'filename': '',  # Field to use to store the filename on ir.attachment
     }
 
+    # pylint: disable=method-required-super
     def create(self, record_values):
         assert self.attachment
         if not record_values:

--- a/logging_json/json_log.py
+++ b/logging_json/json_log.py
@@ -35,9 +35,10 @@ class OdooJsonFormatter(jsonlogger.JsonFormatter):
 
 
 if is_true(os.environ.get('ODOO_LOGGING_JSON')):
-    format = ('%(asctime)s %(pid)s %(levelname)s'
-              '%(dbname)s %(name)s: %(message)s')
-    formatter = OdooJsonFormatter(format)
+    formatted_message = (
+        '%(asctime)s %(pid)s %(levelname)s %(dbname)s %(name)s: %(message)s'
+    )
+    formatter = OdooJsonFormatter(formatted_message)
     logging.getLogger().handlers[0].formatter = formatter
 
 


### PR DESCRIPTION
To prevent issues while migrating locally in integration/production mode, here is a proposal to add an environment variable to avoid storage access during migration.