### PR TITLE
Remove the bin_size return

### DIFF
--- a/attachment_azure/models/ir_attachment.py
+++ b/attachment_azure/models/ir_attachment.py
@@ -164,10 +164,7 @@ class IrAttachment(models.Model):
                 return ''
             try:
                 blob_client = container_client.get_blob_client(key)
-                if bin_size:
-                    return blob_client.get_blob_properties()['size']
-                else:
-                    read = base64.b64encode(blob_client.download_blob().readall())
+                read = base64.b64encode(blob_client.download_blob().readall())
             except HttpResponseError:
                 read = ""
                 _logger.info("Attachment '%s' missing on object storage", fname)


### PR DESCRIPTION
When we return a bin_size (such as 28672), the web client does not
accept it as as bin size and try to use it as value for the b64 src of
the image.  Though, returning the image as b64 in all cases does seem to
be supported.

This comes from 9ca3f876149028242cc43ef334af4e4746b2f5d0 by Guewen
Baconnier