### PR TITLE
[15.0][FW][FIX] session_redis: 'werkzeug.contrib.sessions' is deprecated as of version 0.15

### DIFF
--- a/session_redis/session.py
+++ b/session_redis/session.py
@@ -4,7 +4,7 @@
 import json
 import logging
 
-from werkzeug.contrib.sessions import SessionStore
+from odoo.tools._vendor.sessions import SessionStore
 
 from . import json_encoding
 


### PR DESCRIPTION
Forward port of #345