### PR TITLE
add(attachment_s3): partition fn

### DIFF
--- a/attachment_s3/__manifest__.py
+++ b/attachment_s3/__manifest__.py
@@ -13,6 +13,6 @@
      'python': ['boto3'],
  },
  'website': 'https://www.camptocamp.com',
- 'data': [],
+ 'data': ['data/res_config_settings_data.xml'],
  'installable': True,
  }

--- a/attachment_s3/data/res_config_settings_data.xml
+++ b/attachment_s3/data/res_config_settings_data.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo noupdate="1">
+
+    <record id="ir_attachment_storage_partition" model="ir.config_parameter">
+        <field name="key">ir_attachment.storage.partition</field>
+        <field name="value">%Y-%m</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Not sure if there is any interest in this feature. Seems like would be useful but perhaps other tooling is used. 

Objective: partition the file store into a set of chucks easier to manage. 

adding a customizable partitioning function (date, id range ?) on the files make backup much easier. you may have drops in the past. But should never miss a file as the creates are ordinal, with the right partition fn. then the sync to other environments just need the new partitions, not millions of moves each time. 

review/suggestions? 

just looking and this should not self install like that?

```
period=$(date +%Y-%m)
➜  strapi git:(titan/fix-files-uri) ✗ rclone copyto do_prod:${prod_bucket}/${period}/ do_staging:${other envs}/${period}/ --progress
```
should be much less intensive sync and archive. 
```
y,cnt,size_total
2022-01,14924,751845829
2022-02,14633,880372327
2022-03,27232,2825859897
2022-04,32789,2875873528
2022-05,32882,3557035499
2022-06,30060,3019123692
2022-07,24816,2683203413
2022-08,3564,465700135
```
cc:
@max3903 
@vrenaville 