### PR TITLE
[FIX] requirements: use cryptography==35.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cryptography==35.0.0
 azure-storage-blob==12.8.1
 azure-identity==1.6.0
 boto3==1.9.102


### PR DESCRIPTION
Odoo requires maxiumn verison of cryptography to be 35.0.0 (https://github.com/odoo/odoo/blob/15.0/requirements.txt#L3) but azure-storage-blob could take to an upgrade to latest version (38.x) With this fix we pre-intall cryptography==35.0.0 before azure-storage-blob could update it