### PR TITLE
Patch travis dependency of MQT for py3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
     - "/^[[:digit:]]{1,2}.[[:digit:]]$/"
 
 python:
-  - "3.5"
+  - "3.8"
 
 addons:
   postgresql: "9.5"


### PR DESCRIPTION
This is an attempt to quickly patch branch 12.0.

A better approach would be to use https://github.com/OCA/oca-addons-repo-template/tree/master/.github/workflows