### PR TITLE
azure_attachment: handle no container client

### DIFF
--- a/attachment_azure/models/ir_attachment.py
+++ b/attachment_azure/models/ir_attachment.py
@@ -173,6 +173,8 @@ class IrAttachment(models.Model):
         location = self.env.context.get("storage_location") or self._storage()
         if location == "azure":
             container_client = self._get_azure_container()
+            if not container_client:
+                return ""
             filename = "azure://%s/%s" % (container_client.container_name, key)
             with io.BytesIO() as file:
                 blob_client = container_client.get_blob_client(key.lower())


### PR DESCRIPTION
In `_store_file_write`, `_get_azure_container` is called and might return `False` in some cases.
This is never checked afterwards, and we might get a `AttributeError: 'bool' object has no attribute 'container_name'` exception in such case.

edit: I used the same approach as the one used in `_store_file_read` and `_store_file_delete`, but I would have preferred to propagate the exception instead. Which, I suppose, would be easier to debug. However, I'm not sure what such change would imply in the rest of the code.