### PR TITLE
[16.0] session_redis: allow kwargs in session vacuum

### DIFF
--- a/session_redis/session.py
+++ b/session_redis/session.py
@@ -117,7 +117,7 @@ class RedisSessionStore(SessionStore):
             session.session_token = security.compute_session_token(session, env)
         self.save(session)
 
-    def vacuum(self):
+    def vacuum(self, **kwargs):
         """Do not garbage collect the sessions
 
         Redis keys are automatically cleaned at the end of their


### PR DESCRIPTION
The vacuum method from the SessionStore class now takes an argument `max_lifetime`   
This change was made in the following PR: https://github.com/odoo/odoo/pull/122888  
To avoid GC errors in the latest Odoo 16 version of the session_reddis the vacuum method method can now handle any kwargs.