### PR TITLE
base_attachment_storage: _register_hook do nothing if it is disabled

### DIFF
--- a/base_attachment_object_storage/models/ir_attachment.py
+++ b/base_attachment_object_storage/models/ir_attachment.py
@@ -79,7 +79,7 @@ class IrAttachment(models.Model):
         # migration here.
         # Typical example is images of ir.ui.menu which are updated in
         # ir.attachment at every upgrade of the addons
-        if update_module:
+        if update_module and not self.is_storage_disabled(location):
             self.env["ir.attachment"].sudo()._force_storage_to_object_storage()
 
     @property


### PR DESCRIPTION
When doing a migration and installing the module and having disabled the storage. I don't want the register hook to do anything.