### PR TITLE
[16.0] Removed api.Environment.manage WARNING + added missing parameter max_lifetime + auto_install attachment_s3

### DIFF
--- a/attachment_s3/__manifest__.py
+++ b/attachment_s3/__manifest__.py
@@ -15,5 +15,5 @@
     },
     "website": "https://github.com/camptocamp/odoo-cloud-platform",
     "data": [],
-    "installable": False,
+    "installable": True,
 }

--- a/attachment_s3/__manifest__.py
+++ b/attachment_s3/__manifest__.py
@@ -15,6 +15,5 @@
     },
     "website": "https://github.com/camptocamp/odoo-cloud-platform",
     "data": [],
-    "installable": True,
-    "auto_install": True,
+    "installable": False,
 }

--- a/attachment_s3/__manifest__.py
+++ b/attachment_s3/__manifest__.py
@@ -16,4 +16,5 @@
     "website": "https://github.com/camptocamp/odoo-cloud-platform",
     "data": [],
     "installable": True,
+    "auto_install": True
 }

--- a/attachment_s3/__manifest__.py
+++ b/attachment_s3/__manifest__.py
@@ -15,5 +15,6 @@
     },
     "website": "https://github.com/camptocamp/odoo-cloud-platform",
     "data": [],
-    "installable": False,
+    "installable": True,
+    "auto_install": True,
 }

--- a/base_attachment_object_storage/models/ir_attachment.py
+++ b/base_attachment_object_storage/models/ir_attachment.py
@@ -260,22 +260,21 @@ class IrAttachment(models.Model):
 
         Using a new Odoo Environment thus a new PG transaction.
         """
-        with api.Environment.manage():
-            if new_cr:
-                registry = odoo.modules.registry.Registry.new(self.env.cr.dbname)
-                with closing(registry.cursor()) as cr:
-                    try:
-                        yield self.env(cr=cr)
-                    except Exception:
-                        cr.rollback()
-                        raise
-                    else:
-                        # disable pylint error because this is a valid commit,
-                        # we are in a new env
-                        cr.commit()  # pylint: disable=invalid-commit
-            else:
-                # make a copy
-                yield self.env()
+        if new_cr:
+            registry = odoo.modules.registry.Registry.new(self.env.cr.dbname)
+            with closing(registry.cursor()) as cr:
+                try:
+                    yield self.env(cr=cr)
+                except Exception:
+                    cr.rollback()
+                    raise
+                else:
+                    # disable pylint error because this is a valid commit,
+                    # we are in a new env
+                    cr.commit()  # pylint: disable=invalid-commit
+        else:
+            # make a copy
+            yield self.env()
 
     def _move_attachment_to_store(self):
         self.ensure_one()

--- a/session_redis/session.py
+++ b/session_redis/session.py
@@ -117,7 +117,7 @@ class RedisSessionStore(SessionStore):
             session.session_token = security.compute_session_token(session, env)
         self.save(session)
 
-    def vacuum(self):
+    def vacuum(self, max_lifetime=DEFAULT_SESSION_TIMEOUT):
         """Do not garbage collect the sessions
 
         Redis keys are automatically cleaned at the end of their


### PR DESCRIPTION
1. `api.Environment.manage` was deprecated since Odoo 15.0
2. `max_lifetime` was required (not sure if it wasn't before) as it prompts a WARNING
3. It's common to combine `base_attachment_object_storage` with `attachment_s3` it's annoying to install it every time specially when working in dockerized environments where this addons are being cloned on build time and not quite easy to edit.