### PR TITLE
[16.0] Add module spreadsheet_dashboard_force_db_storage

### DIFF
--- a/setup/spreadsheet_dashboard_force_db_storage/odoo/addons/spreadsheet_dashboard_force_db_storage
+++ b/setup/spreadsheet_dashboard_force_db_storage/odoo/addons/spreadsheet_dashboard_force_db_storage
@@ -1,0 +1,1 @@
+../../../../spreadsheet_dashboard_force_db_storage

--- a/setup/spreadsheet_dashboard_force_db_storage/setup.py
+++ b/setup/spreadsheet_dashboard_force_db_storage/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/spreadsheet_dashboard_force_db_storage/README.rst
+++ b/spreadsheet_dashboard_force_db_storage/README.rst
@@ -1,0 +1,15 @@
+======================================
+Spreadsheet Dashboard Force DB storage
+======================================
+
+This module allows to force storage of spreadsheet dashboard data in the database
+instead of any external storage that is configured.
+
+When using `base_attachment_object_storage`, Odoo attachments' binaries data that
+are stored on object storage use a storage key that is computed according to the
+content of the binary data (ie checksum).
+It works well as long as they are not meant to be modified, since it avoids duplication
+of identical content on the object storage.
+However, the spreadsheet dashboard records' binary data is meant to be modified and
+the default worksheet data still has to be duplicated among the spreadsheet dashboard
+records, to allow modification for each spreadsheet.

--- a/spreadsheet_dashboard_force_db_storage/__init__.py
+++ b/spreadsheet_dashboard_force_db_storage/__init__.py
@@ -1,0 +1,3 @@
+from . import models
+from .hooks import pre_init_hook
+from .hooks import uninstall_hook

--- a/spreadsheet_dashboard_force_db_storage/__manifest__.py
+++ b/spreadsheet_dashboard_force_db_storage/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Spreadsheet Dashboard Force DB Storage",
+    "summary": "Force storage of attachments from spreadsheet dashboards in DB",
+    "version": "16.0.1.0.0",
+    "category": "Uncategorized",
+    "website": "https://github.com/camptocamp/odoo-cloud-platform",
+    "author": "Camptocamp",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "pre_init_hook": "pre_init_hook",
+    "uninstall_hook": "uninstall_hook",
+    "depends": [
+        "spreadsheet_dashboard",
+    ],
+}

--- a/spreadsheet_dashboard_force_db_storage/hooks.py
+++ b/spreadsheet_dashboard_force_db_storage/hooks.py
@@ -1,0 +1,57 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import SUPERUSER_ID, api
+
+
+def pre_init_hook(cr):
+    """Move binary data from storage to DB"""
+    # Create DB column
+    cr.execute("ALTER TABLE spreadsheet_dashboard ADD COLUMN data bytea NULL;")
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    # Read from storage
+    records_data = env["spreadsheet.dashboard"].search_read(fields=["data"])
+    # Write into DB
+    for rec in records_data:
+        cr.execute(
+            "UPDATE spreadsheet_dashboard SET data = %s WHERE id = %s;",
+            tuple([rec.get("data"), rec.get("id")]),
+        )
+    cr.execute("ALTER TABLE spreadsheet_dashboard ALTER COLUMN data SET NOT NULL;")
+    # Delete attachments
+    data_field = env["spreadsheet.dashboard"]._fields["data"]
+    attachments = env["ir.attachment"].search(
+        [
+            ("name", "=", data_field.name),
+            ("res_model", "=", data_field.model_name),
+            ("res_field", "=", data_field.name),
+            ("type", "=", "binary"),
+            ("res_id", "in", [rec.get("id") for rec in records_data]),
+        ]
+    )
+    attachments.unlink()
+
+
+def uninstall_hook(cr, registry):
+    """Move binary data from DB to storage"""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    # Read from DB
+    records_data = env["spreadsheet.dashboard"].search_read(fields=["data"])
+    data_field = env["spreadsheet.dashboard"]._fields["data"]
+    # Create attachments
+    with env.norecompute():
+        env["ir.attachment"].create(
+            [
+                {
+                    "name": data_field.name,
+                    "res_model": data_field.model_name,
+                    "res_field": data_field.name,
+                    "res_id": rec.get("id"),
+                    "type": "binary",
+                    "datas": rec.get("data"),
+                }
+                for rec in records_data
+                if rec.get("data")
+            ]
+        )
+    # Delete from DB
+    cr.execute("ALTER TABLE spreadsheet_dashboard DROP COLUMN data;")

--- a/spreadsheet_dashboard_force_db_storage/models/__init__.py
+++ b/spreadsheet_dashboard_force_db_storage/models/__init__.py
@@ -1,0 +1,1 @@
+from . import spreadsheet_dashboard

--- a/spreadsheet_dashboard_force_db_storage/models/spreadsheet_dashboard.py
+++ b/spreadsheet_dashboard_force_db_storage/models/spreadsheet_dashboard.py
@@ -1,0 +1,10 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class SpreadsheetDashboard(models.Model):
+    _inherit = "spreadsheet.dashboard"
+
+    data = fields.Binary(attachment=False)
+    raw = fields.Binary(attachment=False)


### PR DESCRIPTION
Spreadsheet Dashboard Force DB storage
======================================

This module allows to force storage of spreadsheet dashboard data in the database
instead of any external storage that is configured.

When using `base_attachment_object_storage`, Odoo attachments' binaries data that
are stored on object storage use a storage key that is computed according to the
content of the binary data (ie checksum).
It works well as long as they are not meant to be modified, since it avoids duplication
of identical content on the object storage.
However, the spreadsheet dashboard records' binary data is meant to be modified and
the default worksheet data still has to be duplicated among the spreadsheet dashboard
records, to allow modification for each spreadsheet.