### PR TITLE
[16.0][FIX] logging_json: fix RecursionError

### DIFF
--- a/logging_json/json_log.py
+++ b/logging_json/json_log.py
@@ -26,7 +26,7 @@ def is_true(strval):
 class OdooJsonFormatter(jsonlogger.JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         record.pid = os.getpid()
-        record.dbname = getattr(threading.currentThread(), "dbname", "?")
+        record.dbname = getattr(threading.current_thread(), "dbname", "?")
         record.request_id = getattr(threading.current_thread(), "request_uuid", None)
         record.uid = getattr(threading.current_thread(), "uid", None)
         _super = super(OdooJsonFormatter, self)


### PR DESCRIPTION
Since Python 3.10, the use of `threading.currentThread()` is deprecated and generates a warning, and generating this warning log was in turn entering in the `logging_json` mechanism, triggering an exception:

`RecursionError: maximum recursion depth exceeded while calling a Python object`

This error could be related to `queue.job` stuck in the state `Started` on some projects (to confirm).

EDIT: I confirm that this was blocking some jobs. I don't know why they weren't put in a `Failed` state but instead were still in `Started`, I didn't check.

Traceback:
```
[...]
  File "/odoo/external-src/odoo-cloud-platform/logging_json/json_log.py", line 29, in add_fields
    record.dbname = getattr(threading.currentThread(), "dbname", "?")
  File "/usr/local/lib/python3.10/threading.py", line 1449, in currentThread
    warnings.warn('currentThread() is deprecated, use current_thread() instead',
  File "/usr/local/lib/python3.10/warnings.py", line 109, in _showwarnmsg
    sw(msg.message, msg.category, msg.filename, msg.lineno,
  File "/odoo/src/odoo/netsvc.py", line 292, in showwarning_with_traceback
    return showwarning(
  File "/usr/local/lib/python3.10/logging/__init__.py", line 2245, in _showwarning
    logger.warning("%s", s)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1489, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1624, in _log
    self.handle(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1634, in handle
    self.callHandlers(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1696, in callHandlers
    hdlr.handle(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 968, in handle
    self.emit(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1100, in emit
    msg = self.format(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 943, in format
    return fmt.format(record)
  File "/usr/local/lib/python3.10/site-packages/pythonjsonlogger/jsonlogger.py", line 133, in format
    self.add_fields(log_record, record, message_dict)
  File "/odoo/external-src/odoo-cloud-platform/logging_json/json_log.py", line 29, in add_fields
    record.dbname = getattr(threading.currentThread(), "dbname", "?")
  File "/usr/local/lib/python3.10/threading.py", line 1449, in currentThread
    warnings.warn('currentThread() is deprecated, use current_thread() instead',
  File "/usr/local/lib/python3.10/warnings.py", line 109, in _showwarnmsg
    sw(msg.message, msg.category, msg.filename, msg.lineno,
  File "/odoo/src/odoo/netsvc.py", line 292, in showwarning_with_traceback
    return showwarning(
  File "/usr/local/lib/python3.10/logging/__init__.py", line 2245, in _showwarning
    logger.warning("%s", s)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1489, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1624, in _log
    self.handle(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1634, in handle
    self.callHandlers(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1696, in callHandlers
    hdlr.handle(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 968, in handle
    self.emit(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1100, in emit
    msg = self.format(record)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 943, in format
    return fmt.format(record)
  File "/usr/local/lib/python3.10/site-packages/pythonjsonlogger/jsonlogger.py", line 133, in format
    self.add_fields(log_record, record, message_dict)
  File "/odoo/external-src/odoo-cloud-platform/logging_json/json_log.py", line 29, in add_fields
    record.dbname = getattr(threading.currentThread(), "dbname", "?")
  File "/usr/local/lib/python3.10/threading.py", line 1449, in currentThread
    warnings.warn('currentThread() is deprecated, use current_thread() instead',
  File "/usr/local/lib/python3.10/warnings.py", line 109, in _showwarnmsg
    sw(msg.message, msg.category, msg.filename, msg.lineno,
  File "/odoo/src/odoo/netsvc.py", line 292, in showwarning_with_traceback
    return showwarning(
  File "/usr/local/lib/python3.10/logging/__init__.py", line 2245, in _showwarning
    logger.warning("%s", s)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1489, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1622, in _log
    record = self.makeRecord(self.name, level, fn, lno, msg, args,
  File "/usr/local/lib/python3.10/logging/__init__.py", line 1591, in makeRecord
    rv = _logRecordFactory(name, level, fn, lno, msg, args, exc_info, func,
  File "/odoo/src/odoo/netsvc.py", line 135, in record_factory
    record = old_factory(*args, **kwargs)
  File "/usr/local/lib/python3.10/logging/__init__.py", line 288, in __init__
    ct = time.time()

```