### PR TITLE
[FIX] Import path for ensure db

### DIFF
--- a/monitoring_status/controllers/main.py
+++ b/monitoring_status/controllers/main.py
@@ -8,7 +8,7 @@ import werkzeug
 
 from odoo import http
 
-from odoo.addons.web.controllers.main import ensure_db
+from odoo.addons.web.controllers.utils import ensure_db
 
 
 class HealthCheckFilter(logging.Filter):


### PR DESCRIPTION
Ensure_db is no longer inside the main.py but in utils.py. This PR changes the location for the import.