### PR TITLE
[8.0][FIX] base_attachment_object_storage: no after method on cursor

### DIFF
--- a/base_attachment_object_storage/README.rst
+++ b/base_attachment_object_storage/README.rst
@@ -3,5 +3,8 @@ Base class for attachments on external object store
 
 This is a base addon that regroups common code used by addons targeting specific object store.
 
-
+When a module is installed or upgraded, this module moves any attachments to the configured object storage.
+As there is no method to allow cleaning up the file system after a commit, the file are left in place.
+Set the environment variable `ODOO_ADDON_BASE_ATTACHMENT_OBJECT_STORAGE_CLEAN_FILESYSTEM` to true to force
+removing the copied file immediately.
 

--- a/base_attachment_object_storage/models/ir_attachment.py
+++ b/base_attachment_object_storage/models/ir_attachment.py
@@ -257,13 +257,10 @@ class IrAttachment(osv.osv):
                 _logger.error('Could not migrate attachment %s to %s' %
                               (attachment_id, storage))
 
-        def clean():
+        clean_filesystem = os.environ.get('ODOO_ADDON_BASE_ATTACHMENT_OBJECT_STORAGE_CLEAN_FILESYSTEM', False) in ("True", "true", True)
+        # delete the files from the filesystem
+        if files_to_clean and clean_filesystem:
             clean_fs(files_to_clean)
-
-        # delete the files from the filesystem once we know the changes
-        # have been committed in ir.attachment
-        if files_to_clean:
-            cr.after('commit', clean)
 
     def _get_stores(self):
         """ To get the list of stores activated in the system  """


### PR DESCRIPTION
Add an environment variable to clean up immediately, defaulting to keep the files in case of trouble.