### PR TITLE
[FIX] _object_storage: 'bool' object has no attribute 'partition'

### DIFF
--- a/base_attachment_object_storage/models/ir_attachment.py
+++ b/base_attachment_object_storage/models/ir_attachment.py
@@ -281,7 +281,7 @@ class IrAttachment(models.Model):
         self.ensure_one()
         _logger.info("inspecting attachment %s (%d)", self.name, self.id)
         fname = self.store_fname
-        storage = fname.partition("://")[0]
+        storage = fname and fname.partition("://")[0]
         if self.is_storage_disabled(storage):
             fname = False
         if fname:


### PR DESCRIPTION
While upgrading a database to new version (from 13 to 16, both versions with this module) When running the -u all we face this issue on some databases. We didn't find the root cause yet.