### PR TITLE
[17.0][FIX] session_redis: fix vacuum

### DIFF
--- a/session_redis/session.py
+++ b/session_redis/session.py
@@ -117,7 +117,7 @@ class RedisSessionStore(SessionStore):
             session.session_token = security.compute_session_token(session, env)
         self.save(session)
 
-    def vacuum(self):
+    def vacuum(self, *args, **kwargs):
         """Do not garbage collect the sessions
 
         Redis keys are automatically cleaned at the end of their


### PR DESCRIPTION
`Session.vacuum` method contains extra arguments since this PR https://github.com/odoo/odoo/pull/122888

accept parameters to adapter this change

Port of #454 for 17.0