### PR TITLE
[FIX] Enable session_redis to work with Sentry

### DIFF
--- a/session_redis/http.py
+++ b/session_redis/http.py
@@ -89,6 +89,26 @@ if is_true(os.getenv("ODOO_SESSION_REDIS")):
             host,
             port,
         )
-    http.Application.session_store = session_store
+    target = http.Application
+    if not hasattr(target, "session_store"):
+        # Some other module (at least OCA/server-tools/sentry) has replaced
+        # Application with a different object, hopefully wrapping it instead of
+        # completely overwriting it
+        # Try and see if we can extract the proper object from http.root instead
+        if not hasattr(http.root, "session_store"):
+            raise Exception(
+                "session_redis: unable to find correct objects to patch for "
+                "session management. Has another module overwritten "
+                "odoo.http.Application with a different object?"
+            )
+        else:
+            _logger.warning(
+                "Extracting underlying web app object from odoo.http.root, as "
+                "the actual Application object has been replaced. This may not "
+                "work correctly: if you can affect load order, try to make "
+                "session_redis load before other server-wide modules."
+            )
+            target = type(http.root)
+    target.session_store = session_store
     # clean the existing sessions on the file system
     purge_fs_sessions(config.session_dir)


### PR DESCRIPTION
ref: https://github.com/avoinsystems/odoo-cloud-platform/commit/a09a8136d5e79a4f00b7a5645e87e677ada4ed1e

When the sentry module is loaded, it overrides odoo.http.Application with a middleware object that wraps the original, but does not proxy it. Thus the session_store property that session_redis monkeypatches is no longer there.

This fix intends to avoid that, without having very specific knowledge about the sentry module baked in.

The solution seems to work, but has the risk that if the Application class is fully replaced (i.e. if it is not even wrapped), then this new method may lead to this module simply not working, and the reasons for it may be difficult to debug. But the only way around that would be to explicitly check the wrapper object contains the expected class, and that is basically the same as depending on the sentry module.

