### PR TITLE
[18.0][FIX] logging_json: warning jsonlogger

### DIFF
--- a/logging_json/json_log.py
+++ b/logging_json/json_log.py
@@ -13,17 +13,17 @@ from .strtobool import strtobool
 _logger = logging.getLogger(__name__)
 
 try:
-    from pythonjsonlogger import jsonlogger
+    from pythonjsonlogger.json import JsonFormatter
 except ImportError:
-    jsonlogger = None  # noqa
-    _logger.debug("Cannot 'import pythonjsonlogger'.")
+    JsonFormatter = None  # noqa
+    _logger.debug("Cannot 'import JsonFormatter from '.")
 
 
 def is_true(strval):
     return bool(strtobool(strval or "0".lower()))
 
 
-class OdooJsonFormatter(jsonlogger.JsonFormatter):
+class OdooJsonFormatter(JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         record.pid = os.getpid()
         record.dbname = getattr(threading.currentThread(), "dbname", "?")


### PR DESCRIPTION
Odoo warning:
`2025-02-21 17:45:42,352 43254 WARNING train-adhoc-21-02-1 py.warnings: /usr/local/lib/python3.10/site-packages/pythonjsonlogger/jsonlogger.py:11: DeprecationWarning: pythonjsonlogger.jsonlogger has been moved to pythonjsonlogger.json
`

Library doc:
https://nhairs.github.io/python-json-logger/latest/reference/pythonjsonlogger/jsonlogger/

Implementation code:
https://github.com/nhairs/python-json-logger/blob/main/src/pythonjsonlogger/jsonlogger.py