### PR TITLE
[FIX] logging_json: deprecated method currentThread

### DIFF
--- a/logging_json/json_log.py
+++ b/logging_json/json_log.py
@@ -26,7 +26,7 @@ def is_true(strval):
 class OdooJsonFormatter(jsonlogger.JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         record.pid = os.getpid()
-        record.dbname = getattr(threading.currentThread(), "dbname", "?")
+        record.dbname = getattr(threading.current_thread(), "dbname", "?")
         record.request_id = getattr(threading.current_thread(), "request_uuid", None)
         record.uid = getattr(threading.current_thread(), "uid", None)
         _super = super()


### PR DESCRIPTION
Avoid warning:
DeprecationWarning: currentThread() is deprecated, use current_thread() instead