### PR TITLE
fix: adapt import of jsonlogger

### DIFF
--- a/logging_json/json_log.py
+++ b/logging_json/json_log.py
@@ -13,9 +13,9 @@ from .strtobool import strtobool
 _logger = logging.getLogger(__name__)
 
 try:
-    from pythonjsonlogger import jsonlogger
+    from pythonjsonlogger.json import JsonFormatter
 except ImportError:
-    jsonlogger = None  # noqa
+    JsonFormatter = None  # noqa
     _logger.debug("Cannot 'import pythonjsonlogger'.")
 
 
@@ -23,7 +23,7 @@ def is_true(strval):
     return bool(strtobool(strval or "0".lower()))
 
 
-class OdooJsonFormatter(jsonlogger.JsonFormatter):
+class OdooJsonFormatter(JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         record.pid = os.getpid()
         record.dbname = getattr(threading.currentThread(), "dbname", "?")


### PR DESCRIPTION
Since `jsonlogger` version 3.1.0 (May 2023), the library was refactored.

Here is code adaptation to avoid DeprecationWarning tracebacks such as:

```
2025-05-06 07:11:15,651 1 WARNING dev py.warnings: /odoo/.venv/lib/python3.12/site-packages/pythonjsonlogger/jsonlogger.py:11: DeprecationWarning: pythonjsonlogger.jsonlogger has been moved to pythonjsonlogger.json
  File "/odoo/.venv/bin/odoo", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/odoo/src/odoo/setup/odoo", line 8, in <module>
    odoo.cli.main()
  File "/odoo/src/odoo/odoo/cli/command.py", line 66, in main
    o.run(args)
  File "/odoo/src/odoo/odoo/cli/server.py", line 182, in run
    main(args)
  File "/odoo/src/odoo/odoo/cli/server.py", line 175, in main
    rc = odoo.service.server.start(preload=preload, stop=stop)
  File "/odoo/src/odoo/odoo/service/server.py", line 1424, in start
    rc = server.run(preload, stop)
  File "/odoo/src/odoo/odoo/service/server.py", line 589, in run
    rc = preload_registries(preload)
  File "/odoo/src/odoo/odoo/service/server.py", line 1328, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/odoo/.venv/lib/python3.12/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/odoo/src/odoo/odoo/tools/func.py", line 97, in locked
    return func(inst, *args, **kwargs)
  File "/odoo/src/odoo/odoo/modules/registry.py", line 127, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/odoo/src/odoo/odoo/modules/loading.py", line 480, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "/odoo/src/odoo/odoo/modules/loading.py", line 365, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/odoo/src/odoo/odoo/modules/loading.py", line 186, in load_module_graph
    load_openerp_module(package.name)
  File "/odoo/src/odoo/odoo/modules/module.py", line 384, in load_openerp_module
    __import__(qualname)
  File "/odoo/odoo/external-src/odoo-cloud-platform/logging_json/__init__.py", line 1, in <module>
    from . import json_log
  File "/odoo/odoo/external-src/odoo-cloud-platform/logging_json/json_log.py", line 16, in <module>
    from pythonjsonlogger import jsonlogger
  File "/odoo/.venv/lib/python3.12/site-packages/pythonjsonlogger/jsonlogger.py", line 11, in <module>
    warnings.warn(
```  
