### PR TITLE
[15.0][FIX] session_redis: add incompatibility to auth_session_timeout

### DIFF
--- a/session_redis/__manifest__.py
+++ b/session_redis/__manifest__.py
@@ -10,6 +10,10 @@
     "license": "AGPL-3",
     "category": "Extra Tools",
     "depends": ["base"],
+    "excludes": [
+        # OCA/server-auth
+        "auth_session_timeout",
+    ],
     "external_dependencies": {
         "python": ["redis"],
     },


### PR DESCRIPTION
``session_redis`` is not compatible with ``auth_session_timeout``.

``session_redis`` overrides property ``odoo.http.Application.session_store`` by returning a ``RedisSessionStore`` object instead of a ``odoo.http.FilesystemSessionStore`` object.
``auth_session_timeout`` expects ``odoo.http.Application.session_store`` object to define method ``get_session_filename()``, which does not exist for ``RedisSessionStore`` objects.
This results in an ``AttributeError`` that prevents user authentication, and Odoo becomes inaccessible.