### PR TITLE
update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 azure-storage-blob==12.16.0
 azure-identity==1.13.0
 boto3==1.26.7
-redis==4.3.4
+redis
 python-json-logger==2.0.4
 statsd==4.0.1
 python-swiftclient==4.1.0
@@ -9,5 +9,5 @@ python-keystoneclient==5.0.0
 keystoneauth1==5.0.0
 # error with 5.x (ConstructorError: could not determine a constructor for the tag '!record')
 PyYAML==6.0
-prometheus_client==0.15.0
-pyopenssl==22.1.0
+prometheus_client
+pyopenssl


### PR DESCRIPTION
Aligning requirements with 17.0 version
https://github.com/camptocamp/odoo-cloud-platform/blame/17.0/requirements.txt

Following the error:
`	{"asctime": "2025-11-13 13:30:18,272", "pid": 1, "levelname": "ERROR", "dbname": "?", "name": "odoo.http", "message": "Exception during request handling.", "exc_info": "Traceback (most recent call last):\n  File \"/odoo/src/odoo/http.py\", line 2229, in __call__\n    request._post_init()\n  File \"/odoo/src/odoo/http.py\", line 1398, in _post_init\n    self.session, self.db = self._get_session_and_dbname()\n                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/odoo/src/odoo/http.py\", line 1406, in _get_session_and_dbname\n    session = root.session_store.get(sid)\n              ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/odoo/external-src/odoo-cloud-platform/session_redis/session.py\", line 89, in get\n    saved = self.redis.get(key)\n            ^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/redis/client.py\", line 880, in get\n    return self.execute_command('GET', name)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/redis/client.py\", line 572, in execute_command\n    connection.send_command(*args)\n  File \"/usr/local/lib/python3.12/site-packages/redis/connection.py\", line 563, in send_command\n    self.send_packed_command(self.pack_command(*args))\n  File \"/usr/local/lib/python3.12/site-packages/redis/connection.py\", line 538, in send_packed_command\n    self.connect()\n  File \"/usr/local/lib/python3.12/site-packages/redis/connection.py\", line 439, in connect\n    sock = self._connect()\n           ^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.12/site-packages/redis/connection.py\", line 685, in _connect\n    sock = ssl.wrap_socket(sock,\n           ^^^^^^^^^^^^^^^\nAttributeError: module 'ssl' has no attribute 'wrap_socket'", "taskName": null, "perf_info": "", "request_id": "d7f6be79-9013-441d-a423-9985a5b9b06f", "uid": null}`