### PR TITLE
[PERF] fix performance hit

### DIFF
--- a/session_redis/session.py
+++ b/session_redis/session.py
@@ -176,17 +176,10 @@ class RedisSessionStore(SessionStore):
         identifiers = set(identifiers)
         not_found = set()
         for partial_sid in identifiers:
-            try:
-                next(
-                    self.redis.scan_iter(
-                        match=f"{self.prefix}{partial_sid}*",
-                        count=1,
-                    )
-                )
-            except StopIteration:
-                # No matches found
+            key = f"session::{self.prefix}:{partial_sid}*"
+            match = self.redis.keys(pattern=key)
+            if not match:
                 not_found.add(partial_sid)
-
         return not_found
 
     def delete_from_identifiers(self, identifiers: builtins.list[PartialSid]):


### PR DESCRIPTION
On the cloud platform of Camptocamp, a shared redis is used to store the sessions of the different projects -> the number of keys is huge, and using an iterative match kills the performance because of the networking overhead.

We switch to using redis.key(pattern), and since the pattern typically has a leading string which will allow redis to find the correct bucket, the performance should be good.