### PR TITLE
[17.0][FIX] logging_json: no attribute 'JsonFormatter'

### DIFF
--- a/logging_json/json_log.py
+++ b/logging_json/json_log.py
@@ -6,8 +6,6 @@ import os
 import threading
 import uuid
 
-import pythonjsonlogger
-
 from odoo import http
 
 from .strtobool import strtobool
@@ -16,20 +14,21 @@ _logger = logging.getLogger(__name__)
 
 # Module ``jsonlogger`` of package ``python-json-logger`` is deprecated since version
 # 3.1.0, keep it for backward compatibility
-if hasattr(pythonjsonlogger, "json"):
-    jsonlogger = pythonjsonlogger.json
-elif hasattr(pythonjsonlogger, "jsonlogger"):
-    jsonlogger = pythonjsonlogger.jsonlogger
-else:
-    jsonlogger = None  # noqa
-    _logger.debug("Cannot import 'json' or 'jsonlogger' from 'pythonjsonlogger'.")
+try:
+    # python-json-logger>=3.1.0
+    from pythonjsonlogger.json import JsonFormatter as _JsonFormatter
+except ImportError:
+    # python-json-logger<3.1.0
+    from pythonjsonlogger.jsonlogger import (
+        JsonFormatter as _JsonFormatter,
+    )
 
 
 def is_true(strval):
     return bool(strtobool(strval or "0".lower()))
 
 
-class OdooJsonFormatter(jsonlogger.JsonFormatter):
+class OdooJsonFormatter(_JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         record.pid = os.getpid()
         record.dbname = getattr(threading.currentThread(), "dbname", "?")


### PR DESCRIPTION
Fixes
```
Traceback (most recent call last):
  File "/odoo/src/odoo/modules/registry.py", line 110, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/odoo/src/odoo/modules/loading.py", line 485, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "/odoo/src/odoo/modules/loading.py", line 366, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/odoo/src/odoo/modules/loading.py", line 187, in load_module_graph
    load_openerp_module(package.name)
  File "/odoo/src/odoo/modules/module.py", line 395, in load_openerp_module
    __import__(qualname)
  File "/odoo/external-src/odoo-cloud-platform/logging_json/__init__.py", line 1, in <module>
    from . import json_log
  File "/odoo/external-src/odoo-cloud-platform/logging_json/json_log.py", line 32, in <module>
    class OdooJsonFormatter(jsonlogger.JsonFormatter):
AttributeError: 'NoneType' object has no attribute 'JsonFormatter'
2026-03-11 10:31:34,072 82 CRITICAL odoodb odoo.service.server: Failed to initialize database `odoodb`.
Traceback (most recent call last):
  File "/odoo/src/odoo/service/server.py", line 1374, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/usr/local/lib/python3.10/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/odoo/src/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/odoo/src/odoo/modules/registry.py", line 110, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/odoo/src/odoo/modules/loading.py", line 485, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "/odoo/src/odoo/modules/loading.py", line 366, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/odoo/src/odoo/modules/loading.py", line 187, in load_module_graph
    load_openerp_module(package.name)
  File "/odoo/src/odoo/modules/module.py", line 395, in load_openerp_module
    __import__(qualname)
  File "/odoo/external-src/odoo-cloud-platform/logging_json/__init__.py", line 1, in <module>
    from . import json_log
  File "/odoo/external-src/odoo-cloud-platform/logging_json/json_log.py", line 32, in <module>
    class OdooJsonFormatter(jsonlogger.JsonFormatter):
AttributeError: 'NoneType' object has no attribute 'JsonFormatter'
```

Inspired by https://github.com/nolar/kopf/pull/1149