### PR TITLE
[18.0][MIG] logging_json: Migration to 18.0

### DIFF
--- a/logging_json/__manifest__.py
+++ b/logging_json/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "JSON Logging",
-    "version": "16.0.1.0.0",
+    "version": "18.0.1.0.0",
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Extra Tools",


### PR DESCRIPTION
## Summary
Port `logging_json` to Odoo 18.0. Version bump only — module is compatible as-is.

## Changes
- Update version from 16.0 to 18.0 in `__manifest__.py`

## Test plan
- Install on Odoo 18.0 with `ODOO_LOGGING_JSON=1`
- Verify logs output as structured JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)