### PR TITLE
[18.0][MIG] monitoring_log_requests: Migration to 18.0 + param capture

### DIFF
--- a/monitoring_log_requests/__manifest__.py
+++ b/monitoring_log_requests/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Monitoring: Requests Logging",
-    "version": "16.0.1.0.0",
+    "version": "18.0.1.0.0",
     "author": "Camptocamp,Numigi,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "category",

--- a/monitoring_log_requests/models/ir_http.py
+++ b/monitoring_log_requests/models/ir_http.py
@@ -29,8 +29,8 @@ class IrHttp(models.AbstractModel):
 
     @classmethod
     def _monitoring_blacklist(cls, request):
-        path_info = request.httprequest.environ.get("PATH_INFO")
-        if path_info.startswith("/longpolling/"):
+        path_info = request.httprequest.environ.get("PATH_INFO", "")
+        if path_info.startswith(("/longpolling/", "/websocket")):
             return True
         return False
 
@@ -62,8 +62,8 @@ class IrHttp(models.AbstractModel):
             # response things
             "response_status_code": None,
         }
-        if hasattr(request, "status_code"):
-            info["status_code"] = response.status_code
+        if hasattr(response, "status_code"):
+            info["response_status_code"] = response.status_code
         if hasattr(request, "session"):
             info.update(
                 {

--- a/monitoring_log_requests/models/ir_http.py
+++ b/monitoring_log_requests/models/ir_http.py
@@ -3,6 +3,7 @@
 
 import json
 import logging
+import os
 import time
 
 from odoo import models
@@ -10,6 +11,51 @@ from odoo.http import request as http_request
 from odoo.tools.config import config
 
 _logger = logging.getLogger("monitoring.http.requests")
+
+# Maximum size (bytes) for serialized params in log entries.
+# Set MONITORING_LOG_PARAMS_MAX_SIZE=0 to disable param logging.
+PARAMS_MAX_SIZE = int(os.environ.get("MONITORING_LOG_PARAMS_MAX_SIZE", "4096"))
+
+
+def _sanitize_params(params, max_size=PARAMS_MAX_SIZE):
+    """Return a JSON-safe summary of RPC params, excluding binary data.
+
+    Only keeps scalar values (str, int, float, bool, None) and lists of IDs.
+    Truncates the serialized result to max_size bytes.
+    """
+    if not params or max_size <= 0:
+        return None
+
+    def _clean(val, depth=0):
+        if depth > 3:
+            return "..."
+        if val is None or isinstance(val, (bool, int, float)):
+            return val
+        if isinstance(val, str):
+            # Skip binary-like strings (base64 encoded data)
+            if len(val) > 1000:
+                return f"<str len={len(val)}>"
+            return val
+        if isinstance(val, bytes):
+            return f"<bytes len={len(val)}>"
+        if isinstance(val, (list, tuple)):
+            if all(isinstance(v, int) for v in val):
+                # List of IDs — keep as-is
+                return list(val)
+            return [_clean(v, depth + 1) for v in val[:20]]
+        if isinstance(val, dict):
+            return {
+                k: _clean(v, depth + 1)
+                for k, v in list(val.items())[:30]
+                if not isinstance(v, bytes)
+            }
+        return str(type(val).__name__)
+
+    cleaned = _clean(params)
+    result = json.dumps(cleaned, default=str)
+    if len(result) > max_size:
+        return result[:max_size] + "..."
+    return cleaned
 
 
 class IrHttp(models.AbstractModel):
@@ -71,16 +117,22 @@ class IrHttp(models.AbstractModel):
                     "db": request.session.get("db"),
                 }
             )
-        if hasattr(request, "params"):
+        if hasattr(request, "params") and request.params:
             info.update(
                 {
                     "model": request.params.get("model"),
                     "model_method": request.params.get("method"),
-                    "workflow_signal": request.params.get("signal"),
                 }
             )
+            if PARAMS_MAX_SIZE > 0:
+                args = request.params.get("args")
+                kwargs = request.params.get("kwargs")
+                if args:
+                    info["args"] = _sanitize_params(args)
+                if kwargs:
+                    info["kwargs"] = _sanitize_params(kwargs)
         return info
 
     @classmethod
     def _monitoring_log(cls, info):
-        _logger.info(json.dumps(info))
+        _logger.info(json.dumps(info, default=str))


### PR DESCRIPTION
## Summary
Port `monitoring_log_requests` to Odoo 18.0 with bug fixes and parameter capture for audit replay.

## Changes

### Migration
- Update version from 16.0 to 18.0

### Bug fixes
- Add `/websocket` to blacklist (Odoo 18 uses websockets for bus)
- Fix `response_status_code`: was checking `hasattr(request, ...)` instead of `hasattr(response, ...)`
- Add default `""` for `PATH_INFO` to prevent `NoneType.startswith` error

### Improvement: parameter capture
- Add optional RPC parameter logging for audit trail / replay capability
- Controlled by `MONITORING_LOG_PARAMS_MAX_SIZE` env var (default 4096, set 0 to disable)
- Sanitizes params: excludes binary data, truncates large strings, caps total size
- Enables replaying operations from logs on a backup DB

## Test plan
- Install on Odoo 18.0
- Make JSON-RPC calls (e.g. write to a record)
- Verify logs contain model, method, args, kwargs
- Verify binary fields are excluded from args
- Set `MONITORING_LOG_PARAMS_MAX_SIZE=0` and verify args are not logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)