### PR TITLE
[18.0][FIX] monitoring_log_requests: fix blacklist and status_code

### DIFF
--- a/monitoring_log_requests/models/ir_http.py
+++ b/monitoring_log_requests/models/ir_http.py
@@ -29,8 +29,8 @@ class IrHttp(models.AbstractModel):
 
     @classmethod
     def _monitoring_blacklist(cls, request):
-        path_info = request.httprequest.environ.get("PATH_INFO")
-        if path_info.startswith("/longpolling/"):
+        path_info = request.httprequest.environ.get("PATH_INFO", "")
+        if path_info.startswith(("/longpolling/", "/websocket")):
             return True
         return False
 
@@ -62,8 +62,8 @@ class IrHttp(models.AbstractModel):
             # response things
             "response_status_code": None,
         }
-        if hasattr(request, "status_code"):
-            info["status_code"] = response.status_code
+        if hasattr(response, "status_code"):
+            info["response_status_code"] = response.status_code
         if hasattr(request, "session"):
             info.update(
                 {


### PR DESCRIPTION
## Summary
Fix three bugs in the 18.0 port of monitoring_log_requests.

## Fixes
- Add `/websocket` to blacklist (Odoo 18 uses websockets for bus notifications instead of longpolling)
- Fix `response_status_code`: `hasattr` checked `request` instead of `response`, and wrote to wrong key name
- Add default `""` for `PATH_INFO` to prevent `NoneType.startswith` error