### PR TITLE
[18.0][REF] cloud_platform,monitoring_prometheus: server_environment should not be a required dependency

### DIFF
--- a/cloud_platform/__manifest__.py
+++ b/cloud_platform/__manifest__.py
@@ -5,17 +5,11 @@
 {
     "name": "Cloud Platform",
     "summary": "Addons required for the Camptocamp Cloud Platform",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Extra Tools",
-    "depends": [
-        "session_redis",
-        "monitoring_status",
-        "logging_json",
-        "server_environment",  # OCA/server-tools
-    ],
+    "depends": ["session_redis", "monitoring_status", "logging_json"],
     "website": "https://github.com/camptocamp/odoo-cloud-platform",
-    "data": [],
     "installable": True,
 }

--- a/cloud_platform/models/cloud_platform.py
+++ b/cloud_platform/models/cloud_platform.py
@@ -6,7 +6,6 @@ import os
 import re
 
 from odoo import api, models
-from odoo.tools.config import config
 
 from .strtobool import strtobool
 
@@ -22,7 +21,7 @@ class CloudPlatform(models.AbstractModel):
     _description = "cloud.platform"
 
     def _get_running_env(self):
-        environment_name = config["running_env"]
+        environment_name = os.environ.get("RUNNING_ENV")
         if environment_name.startswith("labs"):
             # We allow to have environments such as 'labs-logistics'
             # or 'labs-finance', in order to have the matching ribbon.

--- a/monitoring_prometheus/__manifest__.py
+++ b/monitoring_prometheus/__manifest__.py
@@ -4,17 +4,12 @@
 
 {
     "name": "Monitoring: Prometheus Metrics",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "category": "category",
-    "depends": [
-        "base",
-        "web",
-        "server_environment",
-    ],
+    "category": "Extra Tools",
+    "depends": ["base", "web"],
     "website": "https://github.com/camptocamp/odoo-cloud-platform",
-    "data": [],
     "external_dependencies": {
         "python": ["prometheus_client"],
     },

--- a/monitoring_prometheus/models/ir_http.py
+++ b/monitoring_prometheus/models/ir_http.py
@@ -17,6 +17,8 @@ class IrHttp(models.AbstractModel):
 
     @classmethod
     def _dispatch(cls, endpoint):
+        # httprequest environment is updated with WSGI environment variables in core
+        # REF: https://github.com/odoo/odoo/blob/18.0/odoo/http.py#L1992
         path_info = request.httprequest.environ.get("PATH_INFO")
 
         if path_info.startswith("/longpolling/"):


### PR DESCRIPTION
PR is aimed to remove `server_environment` dependency from `cloud_platform` and `monitoring_prometheus` in the scope of this issue:
- [ ] https://github.com/OCA/server-env/issues/258

https://camptocamp.atlassian.net/browse/BSRD-887