### PR TITLE
[17.0][IMP] attachment_azure: downgrade ResourceExistsError log level

### DIFF
--- a/attachment_azure/models/ir_attachment.py
+++ b/attachment_azure/models/ir_attachment.py
@@ -177,8 +177,8 @@ class IrAttachment(models.Model):
                 try:
                     blob_client.upload_blob(file, blob_type="BlockBlob")
                 except ResourceExistsError:
-                    _logger.exception(
-                        "Trying to re create an existing resource %s" % filename
+                    _logger.info(
+                        "Resource already exists, skipping upload for %s", filename
                     )
                 except HttpResponseError as error:
                     # log verbose error from azure, return short message for user


### PR DESCRIPTION
Using _logger.exception for a ResourceExistsError is misleading: the operation is harmless since blobs are content-addressed (SHA1) and filename is returned correctly regardless. Switch to _logger.info to avoid false-positive ERROR noise.