### PR TITLE
[17.0][IMP] attachment_azure: add stack_info on ResourceExistsError 

### DIFF
--- a/attachment_azure/models/ir_attachment.py
+++ b/attachment_azure/models/ir_attachment.py
@@ -177,8 +177,12 @@ class IrAttachment(models.Model):
                 try:
                     blob_client.upload_blob(file, blob_type="BlockBlob")
                 except ResourceExistsError:
-                    _logger.exception(
-                        "Trying to re create an existing resource %s" % filename
+                    (
+                        _logger.exception(
+                            "Trying to re create an existing resource %s",
+                            filename,
+                            stack_info=True,
+                        ),
                     )
                 except HttpResponseError as error:
                     # log verbose error from azure, return short message for user


### PR DESCRIPTION
The blob already exists, so the exception traceback (inside upload_blob)
is not useful on its own. Adding stack_info=True to _logger.exception()
also logs the call stack, revealing who triggered the duplicate write.