### PR TITLE
[18.0][FIX] monitoring_prometheus: crash on dead processes, swapped RSS/VMS gauges

### DIFF
--- a/monitoring_prometheus/__manifest__.py
+++ b/monitoring_prometheus/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Monitoring: Prometheus Metrics",
-    "version": "18.0.1.0.1",
+    "version": "18.0.1.0.2",
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Extra Tools",

--- a/monitoring_prometheus/models/psutils_helpers.py
+++ b/monitoring_prometheus/models/psutils_helpers.py
@@ -15,24 +15,29 @@ def get_process_info():
         ["pid", "name", "memory_full_info", "cmdline", "nice"]
     ):
         try:
-            if process.info["memory_full_info"]:
+            mem = process.info["memory_full_info"]
+            # rss == 0 means a zombie/dying process: skip to avoid
+            # publishing garbage series
+            if mem and mem.rss:
+                # cmdline is None for processes that died mid-iteration
+                cmdline = process.info["cmdline"] or []
                 if process.info["nice"] == 10:
                     ProcessLabel = "workercron"
                 elif process.info["pid"] == 1:
                     ProcessLabel = "dispatcher"
-                elif any("gevent" in x for x in process.info["cmdline"]):
+                elif any("gevent" in x for x in cmdline):
                     ProcessLabel = "gevent"
-                elif any("odoo" in x for x in process.info["cmdline"]):
+                elif any("odoo" in x for x in cmdline):
                     ProcessLabel = "workerhttp"
-                elif any("shell" in x for x in process.cmdline()):
+                elif any("shell" in x for x in cmdline):
                     ProcessLabel = "OdooShell"
                 else:
                     ProcessLabel = "other"
                 MEMORY_USAGE_VMS.labels(ProcessLabel, process.info["pid"]).set(
-                    process.info["memory_full_info"].rss // 1000000
+                    mem.vms // 1000000
                 )
                 MEMORY_USAGE_RSS.labels(ProcessLabel, process.info["pid"]).set(
-                    process.info["memory_full_info"].vms // 1000000
+                    mem.rss // 1000000
                 )
 
         except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):


### PR DESCRIPTION
Three bugs found while running `monitoring_prometheus` in production (Odoo 19 port, but the affected code is identical in 18.0 and 19.0):

## 1. Intermittent 500 on `/metrics` — TypeError on `cmdline=None`

`psutil.process_iter` sets `info['cmdline']` to `None` for processes that terminate during iteration. `any(... for x in None)` then raises `TypeError`, which is **not** covered by the `except (NoSuchProcess, AccessDenied, ZombieProcess)` clause, so the whole `/metrics` request fails with 500:

```
File ".../monitoring_prometheus/models/psutils_helpers.py", line 31, in get_process_info
    elif any("gevent" in x for x in process.info["cmdline"]):
TypeError: 'NoneType' object is not iterable
```

Reproduces easily under load (short-lived child processes). Fixed with `cmdline = process.info["cmdline"] or []`.

## 2. RSS and VMS values are swapped

`MEMORY_USAGE_VMS` was fed `.rss` and `MEMORY_USAGE_RSS` was fed `.vms`. Any scrape shows `odoo_worker_memory_user_rss_mb` > `odoo_worker_memory_user_vms_mb`, which is physically impossible (VMS ⩾ RSS always).

## 3. Zombie processes produce garbage series

Zombies report `memory_full_info` with `rss == 0` and an empty cmdline, creating meaningless 0-valued series labelled `other`. Skipped via the `mem.rss` truthiness check.

Also reuses the `cmdline` list for the `'shell'` check instead of a second `process.cmdline()` syscall that can raise `NoSuchProcess` mid-loop.

All three verified in production (multi-worker, prometheus_client 0.25.0). Happy to forward-port to 19.0 once the module migration there lands (it is currently `installable: False`).